### PR TITLE
Chore(docker): multi-stage builds + compose (8081/8082 -> 8080)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+**/build/
+**/.gradle/
+.gradle/
+.git/
+**/*.iml
+.idea/

--- a/backend/challenge-service/Dockerfile
+++ b/backend/challenge-service/Dockerfile
@@ -1,0 +1,20 @@
+# ---- build ----
+FROM gradle:8.14-jdk21 AS build
+WORKDIR /app
+
+COPY settings.gradle build.gradle ./
+
+COPY challenge-service/build.gradle challenge-service/build.gradle
+COPY challenge-service/src challenge-service/src
+
+RUN gradle :challenge-service:bootJar --no-daemon
+
+# ---- runtime ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/challenge-service/build/libs/*-SNAPSHOT.jar app.jar
+
+ENV SERVER_PORT=8081
+EXPOSE 8081
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/challenge-service/build.gradle
+++ b/backend/challenge-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/challenge-service/build.gradle
+++ b/backend/challenge-service/build.gradle
@@ -19,3 +19,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+tasks.named('jar') {
+	enabled = false
+}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -11,4 +11,4 @@ management:
       probes:
         enabled: true
 server:
-  port: ${SERVER_PORT:8081}
+  port: ${SERVER_PORT:8080}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: challenge-service
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+server:
+  port: ${SERVER_PORT:8081}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  challenge-service:
+    build:
+      context: .
+      dockerfile: challenge-service/Dockerfile
+    environment:
+      SERVER_PORT: 8081
+    ports:
+      - "8081:8081"
+
+  user-service:
+    build:
+      context: .
+      dockerfile: user-service/Dockerfile
+    environment:
+      SERVER_PORT: 8082
+    ports:
+      - "8082:8082"

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,0 +1,20 @@
+# ---- build ----
+FROM gradle:8.14-jdk21 AS build
+WORKDIR /app
+
+COPY settings.gradle build.gradle ./
+
+COPY user-service/build.gradle user-service/build.gradle
+COPY user-service/src user-service/src
+
+RUN gradle :user-service:bootJar --no-daemon
+
+# ---- runtime ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/user-service/build/libs/*-SNAPSHOT.jar app.jar
+
+ENV SERVER_PORT=8082
+EXPOSE 8082
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -19,3 +19,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+tasks.named('jar') {
+	enabled = false
+}

--- a/backend/user-service/src/main/resources/application.yaml
+++ b/backend/user-service/src/main/resources/application.yaml
@@ -11,4 +11,4 @@ management:
       probes:
         enabled: true
 server:
-  port: ${SERVER_PORT:8082}
+  port: ${SERVER_PORT:8080}

--- a/backend/user-service/src/main/resources/application.yaml
+++ b/backend/user-service/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: user-service
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+server:
+  port: ${SERVER_PORT:8082}


### PR DESCRIPTION
## What are you doing
- Multi-stage Dockerfiles (build JDK21 / runtime JRE21)
- docker-compose (8081/8082 -> 8080 internal)
- bootJar only (disable `jar`)


## Checklist - Backend Dockerization

### Build / Gradle
- [ ] Build stage uses Gradle **8.14** (`FROM gradle:8.14-jdk21`)
- [ ] In **both** microservices: `tasks.named('jar') { enabled = false }` (only `bootJar`)
- [ ] CI command skips tests for now: `./gradlew :challenge-service:bootJar :user-service:bootJar -x test --no-daemon`
      (Follow-up issue opened to add tests)

### Dockerfiles (both services)
- [ ] Multi-stage images: build (Gradle) → runtime (`eclipse-temurin:21-jre`)
- [ ] **No** `ENV SERVER_PORT` hardcoded in the image
- [ ] `EXPOSE 8080` (documentation only)
- [ ] Copies exactly one artifact to runtime: `COPY --from=build .../build/libs/*.jar app.jar`

### Application config
- [ ] `application.yml`: `server.port: ${SERVER_PORT:8080}` in **both** services
- [ ] `spring-boot-starter-actuator` present for health checks

### Docker Compose
- [ ] `challenge-service` ports: `8081:8080` (host → container)
- [ ] `user-service` ports: `8082:8080`
- [ ] (Optional) `environment.SERVER_PORT` omitted since default is 8080

### Repo hygiene
- [ ] `.dockerignore` present and includes: `**/build/`, `**/.gradle/`, `.gradle/`, `.git/`, `**/*.iml`, `.idea/`
- [ ] No `build/`, `.gradle/`, `.env`, IDE files, or secrets in the diff

### Manual validation
- [ ] `docker compose up --build` starts **both** services locally
- [ ] `GET http://localhost:8081/actuator/health` returns 200
- [ ] `GET http://localhost:8082/actuator/health` returns 200