### PR TITLE
chore(docker): promote backend containerization to main (no release)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+**/build/
+**/.gradle/
+.gradle/
+.git/
+**/*.iml
+.idea/

--- a/backend/challenge-service/Dockerfile
+++ b/backend/challenge-service/Dockerfile
@@ -1,0 +1,20 @@
+# ---- build ----
+FROM gradle:8.14-jdk21 AS build
+WORKDIR /app
+
+COPY settings.gradle build.gradle ./
+
+COPY challenge-service/build.gradle challenge-service/build.gradle
+COPY challenge-service/src challenge-service/src
+
+RUN gradle :challenge-service:bootJar --no-daemon
+
+# ---- runtime ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/challenge-service/build/libs/*-SNAPSHOT.jar app.jar
+
+ENV SERVER_PORT=8081
+EXPOSE 8081
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/challenge-service/build.gradle
+++ b/backend/challenge-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/challenge-service/build.gradle
+++ b/backend/challenge-service/build.gradle
@@ -19,3 +19,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+tasks.named('jar') {
+	enabled = false
+}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -11,4 +11,4 @@ management:
       probes:
         enabled: true
 server:
-  port: ${SERVER_PORT:8081}
+  port: ${SERVER_PORT:8080}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: challenge-service
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+server:
+  port: ${SERVER_PORT:8081}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  challenge-service:
+    build:
+      context: .
+      dockerfile: challenge-service/Dockerfile
+    environment:
+      SERVER_PORT: 8081
+    ports:
+      - "8081:8081"
+
+  user-service:
+    build:
+      context: .
+      dockerfile: user-service/Dockerfile
+    environment:
+      SERVER_PORT: 8082
+    ports:
+      - "8082:8082"

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,0 +1,20 @@
+# ---- build ----
+FROM gradle:8.14-jdk21 AS build
+WORKDIR /app
+
+COPY settings.gradle build.gradle ./
+
+COPY user-service/build.gradle user-service/build.gradle
+COPY user-service/src user-service/src
+
+RUN gradle :user-service:bootJar --no-daemon
+
+# ---- runtime ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /app/user-service/build/libs/*-SNAPSHOT.jar app.jar
+
+ENV SERVER_PORT=8082
+EXPOSE 8082
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/user-service/build.gradle
+++ b/backend/user-service/build.gradle
@@ -19,3 +19,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+tasks.named('jar') {
+	enabled = false
+}

--- a/backend/user-service/src/main/resources/application.yaml
+++ b/backend/user-service/src/main/resources/application.yaml
@@ -11,4 +11,4 @@ management:
       probes:
         enabled: true
 server:
-  port: ${SERVER_PORT:8082}
+  port: ${SERVER_PORT:8080}

--- a/backend/user-service/src/main/resources/application.yaml
+++ b/backend/user-service/src/main/resources/application.yaml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: user-service
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+server:
+  port: ${SERVER_PORT:8082}


### PR DESCRIPTION
## What
- Multi-stage Dockerfiles (build JDK21 / runtime JRE21)
- Docker Compose: host 8081/8082 → container 8080
- Only `bootJar` (disable plain `jar`)
- `.dockerignore` added
- `server.port: ${SERVER_PORT:8080}` in both services

## Validation
- `docker compose up --build` starts both services
- Health:
  - `GET http://localhost:8081/actuator/health` → 200
  - `GET http://localhost:8082/actuator/health` → 200

## Notes
- No release yet (AWS/DB/architecture pending)

## Checklist
- [ ] Dockerfiles: no `ENV SERVER_PORT`, `EXPOSE 8080`
- [ ] `application.yml` uses `${SERVER_PORT:8080}` (both services)
- [ ] Compose maps `8081:8080` and `8082:8080`
- [ ] `.dockerignore` present (`**/build/`, `**/.gradle/`, `.idea/`, etc.)