### PR TITLE
chore(frontend): add dev proxy to route API calls to local gateway

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/itachallenge/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
### 🎯 Goal
Enable local frontend → backend communication without CORS or hardcoded base URLs.

### ✅ What’s included
- Added `proxy.conf.json`
- Updated dev start script to use the proxy (`ng serve --proxy-config proxy.conf.json`)
- Routes `/itachallenge/api/*` → `http://localhost:8080`
- Dev-only change (no production impact)

### Frontend:

http://localhost:4200

###  Example (dev):

GET /itachallenge/api/v1/health
→ proxied to http://localhost:8080/itachallenge/api/v1/health