### PR TITLE
chore(frontend): dockerize Angular app with nginx multi-stage build

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+.gitignore
+README.md
+.vscode
+.angular

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# -------- build stage --------
+FROM node:24-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# -------- runtime stage --------
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY --from=build /app/dist/*/browser/ /usr/share/nginx/html/
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}


### PR DESCRIPTION
## 🎯 Goal
Dockerize the Angular frontend so it can run as a production-ready static container.

This standardizes local execution and aligns the project with the future Docker/Compose/AWS deployment strategy.

---

## ✅ What’s included
- Multi-stage Docker build (Node → Nginx)
- Production build generated inside the image (`npm run build`)
- Nginx serving static files
- SPA routing support via `nginx.conf`
- `.dockerignore` to reduce image size
- No runtime Node dependency

---

## 🧱 Architecture
Build stage:
Node 24 → install deps → Angular build

Runtime stage:
Nginx → serve `/usr/share/nginx/html`

---

## 🚀 How to test locally
```bash
docker build -t ita-frontend ./frontend
docker run --rm -p 8081:80 ita-frontend

