### PR TITLE
docs(frontend): improve README for proxy modes and local workflow

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,48 +4,61 @@ Angular application for the ItaChallenges platform.
 
 ---
 
-# ✅ Quick start (recommended)
-
-## Local development (fast iteration)
-
-This is the recommended mode for daily frontend work (HMR / hot reload).
+# Quick start (recommended)
 
 ## Prerequisites
 
 - Node.js 22 (LTS)
 - npm (comes with Node)
+- Docker Desktop
 
 ---
 
-## 1) Start backend (Docker)
+# 1) Start backend
 
 From the repository root:
 
+## Option A — Backend only
+
+```bash
 docker compose \
---profile backend \
--f docker-compose.yml \
--f docker-compose.backend.override.yml \
-up --build
+  --profile backend \
+  -f docker-compose.yml \
+  -f docker-compose.backend.override.yml \
+  up --build
+```
 
-Backend ports exposed to the host:
+Services exposed:
 
-- challenge-service → http://localhost:8081
-- user-service → http://localhost:8082
+- challenge-service → http://localhost:8081  
+- user-service → http://localhost:8082  
 
-Note: If you want gateway-based routing (recommended, production-like), run:
+---
 
+## Option B — Full stack (recommended, production-like)
+
+Starts gateway + backend.
+
+```bash
 docker compose --profile full up --build
+```
 
 Gateway:
 
 http://localhost:8080
 
+All frontend API calls go through the gateway.
+
 ---
 
-## 2) Start frontend (Angular dev server)
+# 2) Start frontend
 
-npm ci  
+From `frontend/`:
+
+```bash
+npm ci
 npm run start:local
+```
 
 Open:
 
@@ -53,87 +66,245 @@ http://localhost:4200
 
 ---
 
-# 🌐 Proxy modes (local vs dev)
+# API and proxy configuration
 
-The frontend uses Angular proxy configuration so API calls can be made with relative URLs.
+The frontend NEVER calls backend services directly.
+
+All calls go through the gateway using this base path:
+
+```
+/itachallenge/api
+```
+
+Example frontend call:
+
+```
+GET /itachallenge/api/v1/challenges
+```
+
+Angular proxy redirects this automatically.
 
 ---
 
-## Local (default)
+# Proxy modes
 
-Uses:
+The project uses proxy files:
 
+```
 proxy.local.json
+proxy.dev.example.json
+```
 
-Targets:
+---
 
-http://localhost:8080
+## Local mode (default)
+
+File:
+
+```
+proxy.local.json
+```
+
+Content:
+
+```json
+{
+  "/itachallenge/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
+  "/actuator": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}
+```
 
 Run:
 
+```bash
 npm run start:local
+```
 
 ---
 
-## Dev / AWS (future)
+## Dev / AWS mode
 
-Copy template:
+Create local file from example:
 
 macOS / Linux:
 
+```bash
 cp proxy.dev.example.json proxy.dev.json
+```
 
 Windows:
 
+```bash
 copy proxy.dev.example.json proxy.dev.json
+```
 
-Edit domain.
+Example content:
+
+```json
+{
+  "/itachallenge/api": {
+    "target": "https://REPLACE_WITH_DEV_GATEWAY_DOMAIN",
+    "secure": true,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
+  "/actuator": {
+    "target": "https://REPLACE_WITH_DEV_GATEWAY_DOMAIN",
+    "secure": true,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}
+```
 
 Run:
 
+```bash
 npm run start:dev
+```
 
-proxy.dev.json is not committed.
+Notes:
+
+- proxy.dev.json is NOT committed
+- Allows switching environments without changing code
 
 ---
 
-# 🧪 Useful scripts
+# Useful scripts
 
-npm start  
-npm run start:local  
-npm run start:dev  
-npm run build  
+```bash
+npm run start:local
+npm run start:dev
+npm run build
 npm run test
+```
 
 ---
 
-# 🏗 Project structure
+# Project structure
 
+```
 src/app/
-
-core/  
-shared/  
-features/  
-layout/
+  core/
+  shared/
+  features/
+  layout/
+```
 
 ---
 
-## Features
+# Features
 
-auth  
-challenges  
-solutions  
-profile  
+```
+auth
+challenges
+solutions
+profile
 admin
+```
+
+Each feature contains:
+
+```
+pages/
+components/
+data-access/
+models/
+```
 
 ---
 
-## Architecture rules
+# Architecture rules
 
-Only data-access/ should use HttpClient.
+Must follow strictly:
 
-Features must not import other features directly.
+- Only data-access/ may use HttpClient
+- Pages must NOT call HttpClient directly
+- Features must NOT import other features
+- shared contains reusable UI only
+- core contains global services only
+- layout contains application shell only
 
-Shared contains reusable UI only.
+---
 
-Core contains global services.
+# Routing
+
+Routing is feature-based and lazy-loaded.
+
+Frontend routes:
+
+```
+/auth
+/challenges
+/solutions
+/profile
+/admin
+```
+
+Backend prefix:
+
+```
+/itachallenge/api
+```
+
+This prefix is handled by gateway and proxy.
+
+Frontend routes MUST NOT include backend prefixes.
+
+Correct:
+
+```
+/challenges
+```
+
+Incorrect:
+
+```
+/itachallenge/api/challenges
+```
+
+---
+
+# Development workflow
+
+Recommended workflow:
+
+1. Start backend
+
+```bash
+docker compose --profile full up --build
+```
+
+2. Start frontend
+
+```bash
+npm run start:local
+```
+
+3. Develop features
+
+4. Commit changes
+
+---
+
+# Production readiness
+
+This setup is compatible with:
+
+- Local Docker development
+- Staging environments
+- AWS deployment
+- Gateway-based routing
+- Microservices architecture
+
+No frontend code changes required between environments.


### PR DESCRIPTION
## Summary

Improves frontend README to be copy-paste friendly for bootcamp students.

## Changes

- Clear quick start steps (backend + frontend)
- Proxy modes documented (local vs dev/AWS)
- Gateway-based routing explained (/itachallenge/api, /actuator)
- Scripts and project structure clarified

## Goal

Make local setup and environment switching simple without changing frontend code.
