### PR TITLE
feat: add submission bounded context skeleton

### DIFF
--- a/backend/challenge-service/README.md
+++ b/backend/challenge-service/README.md
@@ -25,6 +25,24 @@ For general architecture guidelines shared across all backend services see [`bac
 
 ---
 
+## Domain rules
+
+### Submission lifecycle
+
+A user can only have 1 submission per challenge. Once it reaches a terminal state it cannot be changed.
+
+| From | To | Allowed |
+|---|---|---|
+| NONE | IN_PROGRESS | ✅ save draft |
+| NONE | FINAL | ✅ finalize directly |
+| NONE | INCOMPLETE | ✅ mark incomplete directly |
+| IN_PROGRESS | FINAL | ✅ |
+| IN_PROGRESS | INCOMPLETE | ✅ |
+| FINAL | any | ❌ terminal state |
+| INCOMPLETE | any | ❌ terminal state |
+
+---
+
 ## Run locally
 
 ```bash

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/shared/domain/valueobject/UserId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/shared/domain/valueobject/UserId.java
@@ -1,0 +1,10 @@
+package com.itachallenges.challengeservice.shared.domain.valueobject;
+
+import java.util.UUID;
+
+public record UserId(UUID value) {
+    public UserId {
+        if (value == null) throw new IllegalArgumentException("UserId cannot be null");
+    }
+    public static UserId of(String value) { return new UserId(UUID.fromString(value)); }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/FinalizeSubmissionCommand.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/FinalizeSubmissionCommand.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.submission.application.dto;
+
+public record FinalizeSubmissionCommand(
+        String challengeId,
+        String userId,
+        String code
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/MarkIncompleteCommand.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/MarkIncompleteCommand.java
@@ -1,0 +1,6 @@
+package com.itachallenges.challengeservice.submission.application.dto;
+
+public record MarkIncompleteCommand(
+        String submissionId,
+        String userId
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/SaveDraftSubmissionCommand.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/SaveDraftSubmissionCommand.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.submission.application.dto;
+
+public record SaveDraftSubmissionCommand(
+        String challengeId,
+        String userId,
+        String code
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/SubmissionResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/dto/SubmissionResponse.java
@@ -1,0 +1,9 @@
+package com.itachallenges.challengeservice.submission.application.dto;
+
+public record SubmissionResponse(
+        String id,
+        String challengeId,
+        String userId,
+        String status,
+        String code
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -1,0 +1,17 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import com.itachallenges.challengeservice.submission.application.dto.FinalizeSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.port.in.FinalizeSubmissionUseCase;
+
+public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCase {
+    // TODO: inject SubmissionRepository and any other dependencies
+
+    @Override
+    public void execute(FinalizeSubmissionCommand command) {
+        // TODO: check no FINAL submission exists for this user/challenge
+        // TODO: load or create submission
+        // TODO: call submission.finalize()
+        // TODO: save submission
+        // TODO: publish domain events
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
@@ -1,0 +1,16 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import com.itachallenges.challengeservice.submission.application.dto.MarkIncompleteCommand;
+import com.itachallenges.challengeservice.submission.domain.port.in.MarkIncompleteUseCase;
+
+public class MarkIncompleteUseCaseHandler implements MarkIncompleteUseCase {
+    // TODO: inject SubmissionRepository and any other dependencies
+
+    @Override
+    public void execute(MarkIncompleteCommand command) {
+        // TODO: load submission
+        // TODO: call submission.markIncomplete()
+        // TODO: save submission
+        // TODO: publish domain events
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -1,0 +1,14 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+
+public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
+    // TODO: inject SubmissionRepository
+
+    @Override
+    public void execute(SaveDraftSubmissionCommand command) {
+        // TODO: create or update submission with IN_PROGRESS status
+        // TODO: save submission
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -1,0 +1,51 @@
+package com.itachallenges.challengeservice.submission.domain;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionStatus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Submission {
+
+    private SubmissionId id;
+    private ChallengeId challengeId;
+    private UserId userId;
+    private SubmissionStatus status;
+    private String code;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    private final List<Object> domainEvents = new ArrayList<>();
+
+    private Submission() {}
+
+    public static Submission createInProgress(SubmissionId id, ChallengeId challengeId, UserId userId, String code) {
+        // TODO: create and return a new Submission with IN_PROGRESS status
+        return null;
+    }
+
+    public void finalize(String code) {
+        // TODO: transition status to FINAL and emit SubmissionFinished event
+        // TODO: guard against invalid transitions
+    }
+
+    public void markIncomplete() {
+        // TODO: transition status to INCOMPLETE and emit SubmissionMarkedIncomplete event
+        // TODO: guard against invalid transitions
+    }
+
+    public List<Object> pullDomainEvents() {
+        // TODO: return accumulated domain events and clear the list
+        return null;
+    }
+
+    public SubmissionId getId() { return id; }
+    public ChallengeId getChallengeId() { return challengeId; }
+    public UserId getUserId() { return userId; }
+    public SubmissionStatus getStatus() { return status; }
+    public String getCode() { return code; }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/event/SubmissionFinished.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/event/SubmissionFinished.java
@@ -1,0 +1,18 @@
+package com.itachallenges.challengeservice.submission.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+
+import java.time.Instant;
+
+public record SubmissionFinished(
+        SubmissionId submissionId,
+        ChallengeId challengeId,
+        UserId userId,
+        Instant occurredAt
+) {
+    public SubmissionFinished(SubmissionId submissionId, ChallengeId challengeId, UserId userId) {
+        this(submissionId, challengeId, userId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/event/SubmissionMarkedIncomplete.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/event/SubmissionMarkedIncomplete.java
@@ -1,0 +1,18 @@
+package com.itachallenges.challengeservice.submission.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+
+import java.time.Instant;
+
+public record SubmissionMarkedIncomplete(
+        SubmissionId submissionId,
+        ChallengeId challengeId,
+        UserId userId,
+        Instant occurredAt
+) {
+    public SubmissionMarkedIncomplete(SubmissionId submissionId, ChallengeId challengeId, UserId userId) {
+        this(submissionId, challengeId, userId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/FinalizeSubmissionUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/FinalizeSubmissionUseCase.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.submission.domain.port.in;
+
+import com.itachallenges.challengeservice.submission.application.dto.FinalizeSubmissionCommand;
+
+public interface FinalizeSubmissionUseCase {
+    // TODO: define the method signature to finalize a submission
+    void execute(FinalizeSubmissionCommand command);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/MarkIncompleteUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/MarkIncompleteUseCase.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.submission.domain.port.in;
+
+import com.itachallenges.challengeservice.submission.application.dto.MarkIncompleteCommand;
+
+public interface MarkIncompleteUseCase {
+    // TODO: define the method signature to mark a submission as incomplete
+    void execute(MarkIncompleteCommand command);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/SaveDraftSubmissionUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/in/SaveDraftSubmissionUseCase.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.submission.domain.port.in;
+
+import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
+
+public interface SaveDraftSubmissionUseCase {
+    // TODO: define the method signature to save a draft submission
+    void execute(SaveDraftSubmissionCommand command);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/out/SubmissionRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/port/out/SubmissionRepository.java
@@ -1,0 +1,15 @@
+package com.itachallenges.challengeservice.submission.domain.port.out;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.Submission;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+
+import java.util.Optional;
+
+public interface SubmissionRepository {
+    Submission save(Submission submission);
+    Optional<Submission> findById(SubmissionId id);
+    Optional<Submission> findByUserAndChallenge(UserId userId, ChallengeId challengeId);
+    boolean existsFinalSubmission(UserId userId, ChallengeId challengeId);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionId.java
@@ -1,0 +1,11 @@
+package com.itachallenges.challengeservice.submission.domain.valueobject;
+
+import java.util.UUID;
+
+public record SubmissionId(UUID value) {
+    public SubmissionId {
+        if (value == null) throw new IllegalArgumentException("SubmissionId cannot be null");
+    }
+    public static SubmissionId generate() { return new SubmissionId(UUID.randomUUID()); }
+    public static SubmissionId of(String value) { return new SubmissionId(UUID.fromString(value)); }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
@@ -1,0 +1,5 @@
+package com.itachallenges.challengeservice.submission.domain.valueobject;
+
+public enum SubmissionStatus {
+    IN_PROGRESS, FINAL, INCOMPLETE
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -1,0 +1,28 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.controller;
+
+import com.itachallenges.challengeservice.submission.domain.port.in.FinalizeSubmissionUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.in.MarkIncompleteUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/submissions")
+public class SubmissionController {
+
+    private final FinalizeSubmissionUseCase finalizeSubmissionUseCase;
+    private final MarkIncompleteUseCase markIncompleteUseCase;
+    private final SaveDraftSubmissionUseCase saveDraftSubmissionUseCase;
+
+    public SubmissionController(FinalizeSubmissionUseCase finalizeSubmissionUseCase,
+                                MarkIncompleteUseCase markIncompleteUseCase,
+                                SaveDraftSubmissionUseCase saveDraftSubmissionUseCase) {
+        this.finalizeSubmissionUseCase = finalizeSubmissionUseCase;
+        this.markIncompleteUseCase = markIncompleteUseCase;
+        this.saveDraftSubmissionUseCase = saveDraftSubmissionUseCase;
+    }
+
+    // TODO: POST /draft       -> save draft submission
+    // TODO: POST /finalize    -> finalize submission
+    // TODO: POST /incomplete  -> mark submission as incomplete
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/FinalizeSubmissionRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/FinalizeSubmissionRequest.java
@@ -1,0 +1,3 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
+
+public record FinalizeSubmissionRequest(String code) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/MarkIncompleteRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/MarkIncompleteRequest.java
@@ -1,0 +1,6 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
+
+public record MarkIncompleteRequest(
+        String challengeId,
+        String userId
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/SaveDraftSubmissionRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/SaveDraftSubmissionRequest.java
@@ -1,0 +1,3 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
+
+public record SaveDraftSubmissionRequest(String code) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/persistence/InMemorySubmissionRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/persistence/InMemorySubmissionRepository.java
@@ -1,0 +1,39 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.out.persistence;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.Submission;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemorySubmissionRepository implements SubmissionRepository {
+
+    private final Map<SubmissionId, Submission> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public Submission save(Submission submission) {
+        storage.put(submission.getId(), submission);
+        return submission;
+    }
+
+    @Override
+    public Optional<Submission> findById(SubmissionId id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public Optional<Submission> findByUserAndChallenge(UserId userId, ChallengeId challengeId) {
+        // TODO: find submission by userId and challengeId
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsFinalSubmission(UserId userId, ChallengeId challengeId) {
+        // TODO: check if a FINAL submission exists for this userId and challengeId
+        return false;
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandlerTest.java
@@ -1,0 +1,19 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class FinalizeSubmissionUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate FinalizeSubmissionUseCaseHandler
+
+    @Test
+    void shouldFinalizeSubmission() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSubmissionAlreadyFinal() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandlerTest.java
@@ -1,0 +1,19 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class MarkIncompleteUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate MarkIncompleteUseCaseHandler
+
+    @Test
+    void shouldMarkSubmissionAsIncomplete() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSubmissionIsFinal() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
@@ -1,0 +1,14 @@
+package com.itachallenges.challengeservice.submission.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class SaveDraftSubmissionUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate SaveDraftSubmissionUseCaseHandler
+
+    @Test
+    void shouldSaveDraftSubmission() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -1,0 +1,29 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.controller;
+
+import org.junit.jupiter.api.Test;
+
+class SubmissionControllerTest {
+
+    // TODO: setup MockMvc
+    // TODO: mock use cases
+
+    @Test
+    void shouldFinalizeSubmission() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldMarkSubmissionAsIncomplete() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldSaveDraftSubmission() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldReturn400WhenInvalidRequest() {
+        // TODO: implement
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Adds the `submission` bounded context skeleton following the same 
hexagonal architecture pattern established in `catalog`.

## Changes
- New `submission` module with domain, application and infrastructure layers
- Aggregate `Submission` with IN_PROGRESS, FINAL and INCOMPLETE lifecycle
- Domain events: `SubmissionFinished` and `SubmissionMarkedIncomplete`
- Use case interfaces and handlers with TODOs for students to implement
- `InMemorySubmissionRepository` for local development
- `SubmissionController` with endpoint placeholders
- Shared value object `UserId` extracted to `shared.domain.valueobject`
- Test skeletons with TODOs for all use cases and controller
- Updated `challenge-service/README.md` with submission lifecycle rules

## No logic implemented
This is a skeleton PR. Business logic will be implemented by students.

## Reference
Follows the same pattern as `catalog`. See [ADR 001](../blob/develop/backend/challenge-service/docs/adr/001-catalog-bounded-context.md) for architecture decisions.