### PR TITLE
feat: add activity bounded context skeleton

### DIFF
--- a/backend/challenge-service/README.md
+++ b/backend/challenge-service/README.md
@@ -11,8 +11,8 @@ For general architecture guidelines shared across all backend services see [`bac
 | Module | Root Aggregate | Responsibility |
 |---|---|---|
 | `catalog` | `Challenge` | Challenge catalog management |
-| `submissions` | `Submission` | User solution lifecycle |
-| `activity` | `UserActivity` | Favorites and bookmarks per user |
+| `submission` | `Submission` | User solution lifecycle |
+| `activity` | `Activity` | Favorites and bookmarks per user |
 | `stats` | `ChallengeStats` | Global counters per challenge |
 
 ---
@@ -31,26 +31,33 @@ For general architecture guidelines shared across all backend services see [`bac
 
 A user can only have 1 submission per challenge. Once it reaches a terminal state it cannot be changed.
 
-| From | To | Allowed |
-|---|---|---|
-| NONE | IN_PROGRESS | ✅ save draft |
-| NONE | FINAL | ✅ finalize directly |
-| NONE | INCOMPLETE | ✅ mark incomplete directly |
-| IN_PROGRESS | FINAL | ✅ |
-| IN_PROGRESS | INCOMPLETE | ✅ |
-| FINAL | any | ❌ terminal state |
-| INCOMPLETE | any | ❌ terminal state |
+| From         | To          | Allowed                       |
+|:-------------|:------------|:------------------------------|
+| `NONE`       | `IN_PROGRESS` | ✅ save draft               |
+| `NONE`       | `FINAL`     | ✅ finalize directly          |
+| `NONE`       | `INCOMPLETE`| ✅ mark incomplete directly   |
+| `IN_PROGRESS`| `FINAL`     | ✅                            |
+| `IN_PROGRESS`| `INCOMPLETE`| ✅                            |
+| `FINAL`      | any         | ❌ terminal state             |
+| `INCOMPLETE` | any         | ❌ terminal state             |
+
+### Activity rules
+
+| Action | Event emitted | Counter updated |
+|:-------|:-------------|:----------------|
+| Mark favorite | `FavoriteAdded` | `ChallengeStats.favorites + 1` |
+| Unmark favorite | `FavoriteRemoved` | `ChallengeStats.favorites - 1` |
+| Mark bookmark | `BookmarkAdded` | `ChallengeStats.bookmarks + 1` |
+| Unmark bookmark | `BookmarkRemoved` | `ChallengeStats.bookmarks - 1` |
 
 ---
 
 ## Run locally
-
 ```bash
 ./gradlew :challenge-service:bootRun
 ```
 
 ## Tests
-
 ```bash
 ./gradlew :challenge-service:test
 ```

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/dto/ActivityResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/dto/ActivityResponse.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.activity.application.dto;
+
+public record ActivityResponse(
+        String userId,
+        String challengeId,
+        boolean isFavorite,
+        boolean isBookmark
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/dto/ToggleActivityCommand.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/dto/ToggleActivityCommand.java
@@ -1,0 +1,3 @@
+package com.itachallenges.challengeservice.activity.application.dto;
+
+public record ToggleActivityCommand(String userId, String challengeId) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandler.java
@@ -2,7 +2,9 @@ package com.itachallenges.challengeservice.activity.application.usecase;
 
 import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
 import com.itachallenges.challengeservice.activity.domain.port.in.ToggleBookmarkUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class ToggleBookmarkUseCaseHandler implements ToggleBookmarkUseCase {
     // TODO: inject UserActivityRepository and any other dependencies
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandler.java
@@ -1,0 +1,16 @@
+package com.itachallenges.challengeservice.activity.application.usecase;
+
+import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
+import com.itachallenges.challengeservice.activity.domain.port.in.ToggleBookmarkUseCase;
+
+public class ToggleBookmarkUseCaseHandler implements ToggleBookmarkUseCase {
+    // TODO: inject UserActivityRepository and any other dependencies
+
+    @Override
+    public void execute(ToggleActivityCommand command) {
+        // TODO: load or create UserActivity for this userId and challengeId
+        // TODO: call userActivity.toggleBookmark()
+        // TODO: save userActivity
+        // TODO: publish domain events
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandler.java
@@ -2,7 +2,9 @@ package com.itachallenges.challengeservice.activity.application.usecase;
 
 import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
 import com.itachallenges.challengeservice.activity.domain.port.in.ToggleFavoriteUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class ToggleFavoriteUseCaseHandler implements ToggleFavoriteUseCase {
     // TODO: inject UserActivityRepository and any other dependencies
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandler.java
@@ -1,0 +1,16 @@
+package com.itachallenges.challengeservice.activity.application.usecase;
+
+import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
+import com.itachallenges.challengeservice.activity.domain.port.in.ToggleFavoriteUseCase;
+
+public class ToggleFavoriteUseCaseHandler implements ToggleFavoriteUseCase {
+    // TODO: inject UserActivityRepository and any other dependencies
+
+    @Override
+    public void execute(ToggleActivityCommand command) {
+        // TODO: load or create UserActivity for this userId and challengeId
+        // TODO: call userActivity.toggleFavorite()
+        // TODO: save userActivity
+        // TODO: publish domain events
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/Activity.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/Activity.java
@@ -1,0 +1,45 @@
+package com.itachallenges.challengeservice.activity.domain;
+
+import com.itachallenges.challengeservice.activity.domain.valueobject.ActivityId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Activity {
+
+    private ActivityId id;
+    private UserId userId;
+    private ChallengeId challengeId;
+    private boolean favorite;
+    private boolean bookmark;
+
+    private final List<Object> domainEvents = new ArrayList<>();
+
+    private Activity() {}
+
+    public static Activity create(ActivityId id, UserId userId, ChallengeId challengeId) {
+        // TODO: create and return a new UserActivity with favorite and bookmark set to false
+        return null;
+    }
+
+    public void toggleFavorite() {
+        // TODO: toggle favorite and emit FavoriteAdded or FavoriteRemoved event
+    }
+
+    public void toggleBookmark() {
+        // TODO: toggle bookmark and emit BookmarkAdded or BookmarkRemoved event
+    }
+
+    public List<Object> pullDomainEvents() {
+        // TODO: return accumulated domain events and clear the list
+        return null;
+    }
+
+    public ActivityId getId() { return id; }
+    public UserId getUserId() { return userId; }
+    public ChallengeId getChallengeId() { return challengeId; }
+    public boolean isFavorite() { return favorite; }
+    public boolean isBookmark() { return bookmark; }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/BookmarkAdded.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/BookmarkAdded.java
@@ -1,0 +1,12 @@
+package com.itachallenges.challengeservice.activity.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.time.Instant;
+
+public record BookmarkAdded(UserId userId, ChallengeId challengeId, Instant occurredAt) {
+    public BookmarkAdded(UserId userId, ChallengeId challengeId) {
+        this(userId, challengeId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/BookmarkRemoved.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/BookmarkRemoved.java
@@ -1,0 +1,12 @@
+package com.itachallenges.challengeservice.activity.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.time.Instant;
+
+public record BookmarkRemoved(UserId userId, ChallengeId challengeId, Instant occurredAt) {
+    public BookmarkRemoved(UserId userId, ChallengeId challengeId) {
+        this(userId, challengeId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/FavoriteAdded.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/FavoriteAdded.java
@@ -1,0 +1,12 @@
+package com.itachallenges.challengeservice.activity.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.time.Instant;
+
+public record FavoriteAdded(UserId userId, ChallengeId challengeId, Instant occurredAt) {
+    public FavoriteAdded(UserId userId, ChallengeId challengeId) {
+        this(userId, challengeId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/FavoriteRemoved.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/event/FavoriteRemoved.java
@@ -1,0 +1,12 @@
+package com.itachallenges.challengeservice.activity.domain.event;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.time.Instant;
+
+public record FavoriteRemoved(UserId userId, ChallengeId challengeId, Instant occurredAt) {
+    public FavoriteRemoved(UserId userId, ChallengeId challengeId) {
+        this(userId, challengeId, Instant.now());
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/in/ToggleBookmarkUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/in/ToggleBookmarkUseCase.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.activity.domain.port.in;
+
+import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
+
+public interface ToggleBookmarkUseCase {
+    void execute(ToggleActivityCommand command);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/in/ToggleFavoriteUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/in/ToggleFavoriteUseCase.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.activity.domain.port.in;
+
+import com.itachallenges.challengeservice.activity.application.dto.ToggleActivityCommand;
+
+public interface ToggleFavoriteUseCase {
+    void execute(ToggleActivityCommand command);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/out/ActivityRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/port/out/ActivityRepository.java
@@ -1,0 +1,12 @@
+package com.itachallenges.challengeservice.activity.domain.port.out;
+
+import com.itachallenges.challengeservice.activity.domain.Activity;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+
+import java.util.Optional;
+
+public interface ActivityRepository {
+    Activity save(Activity activity);
+    Optional<Activity> findByUserIdAndChallengeId(UserId userId, ChallengeId challengeId);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/valueobject/ActivityId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/domain/valueobject/ActivityId.java
@@ -1,0 +1,13 @@
+package com.itachallenges.challengeservice.activity.domain.valueobject;
+
+import java.util.UUID;
+
+public record ActivityId(UUID value) {
+    public ActivityId {
+        if (value == null) throw new IllegalArgumentException("UserActivityId cannot be null");
+    }
+    public static ActivityId generate() { return new ActivityId(UUID.randomUUID()); }
+    public static ActivityId of(String value) { return new ActivityId(UUID.fromString(value)); }
+    @Override
+    public String toString() { return value.toString(); }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityController.java
@@ -1,0 +1,23 @@
+package com.itachallenges.challengeservice.activity.infrastructure.adapter.in.web.controller;
+
+import com.itachallenges.challengeservice.activity.domain.port.in.ToggleBookmarkUseCase;
+import com.itachallenges.challengeservice.activity.domain.port.in.ToggleFavoriteUseCase;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/challenges")
+public class ActivityController {
+
+    private final ToggleFavoriteUseCase toggleFavoriteUseCase;
+    private final ToggleBookmarkUseCase toggleBookmarkUseCase;
+
+    public ActivityController(ToggleFavoriteUseCase toggleFavoriteUseCase,
+                              ToggleBookmarkUseCase toggleBookmarkUseCase) {
+        this.toggleFavoriteUseCase = toggleFavoriteUseCase;
+        this.toggleBookmarkUseCase = toggleBookmarkUseCase;
+    }
+
+    // TODO: POST /{challengeId}/favorite  -> toggle favorite
+    // TODO: POST /{challengeId}/bookmark  -> toggle bookmark
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/dto/ToggleActivityRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/dto/ToggleActivityRequest.java
@@ -1,0 +1,3 @@
+package com.itachallenges.challengeservice.activity.infrastructure.adapter.in.web.dto;
+
+public record ToggleActivityRequest(String userId) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/out/persistence/InMemoryActivityRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/out/persistence/InMemoryActivityRepository.java
@@ -1,0 +1,30 @@
+package com.itachallenges.challengeservice.activity.infrastructure.adapter.out.persistence;
+
+import com.itachallenges.challengeservice.activity.domain.Activity;
+import com.itachallenges.challengeservice.activity.domain.port.out.ActivityRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryActivityRepository implements ActivityRepository {
+
+    private final Map<String, Activity> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public Activity save(Activity activity) {
+        String key = activity.getUserId().toString() + ":" + activity.getChallengeId().toString();
+        storage.put(key, activity);
+        return activity;
+    }
+
+    @Override
+    public Optional<Activity> findByUserIdAndChallengeId(UserId userId, ChallengeId challengeId) {
+        // TODO: find UserActivity by userId and challengeId
+        return Optional.empty();
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/dto/CreateChallengeResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/dto/CreateChallengeResponse.java
@@ -2,4 +2,4 @@ package com.itachallenges.challengeservice.catalog.application.dto;
 
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 
-public record CreateChallengeResult(ChallengeId id) {}
+public record CreateChallengeResponse(ChallengeId id) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/usecase/CreateChallengeUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/usecase/CreateChallengeUseCaseHandler.java
@@ -1,7 +1,7 @@
 package com.itachallenges.challengeservice.catalog.application.usecase;
 
 import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeCommand;
-import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResult;
+import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResponse;
 import com.itachallenges.challengeservice.catalog.domain.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.in.CreateChallengeUseCase;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
@@ -17,7 +17,7 @@ public class CreateChallengeUseCaseHandler implements CreateChallengeUseCase {
     }
 
     @Override
-    public CreateChallengeResult create(CreateChallengeCommand command) {
+    public CreateChallengeResponse create(CreateChallengeCommand command) {
 
         Challenge challenge = Challenge.createNew(
                 command.title(),
@@ -26,6 +26,6 @@ public class CreateChallengeUseCaseHandler implements CreateChallengeUseCase {
 
         Challenge saved = challengeRepository.save(challenge);
 
-        return new CreateChallengeResult(saved.id());
+        return new CreateChallengeResponse(saved.id());
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/Challenge.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/Challenge.java
@@ -19,7 +19,7 @@ public class Challenge {
     }
 
     public static Challenge createNew(String title, String description) {
-        return new Challenge(ChallengeId.random(), title, description);
+        return new Challenge(ChallengeId.generate(), title, description);
     }
 
     public static Challenge restore(ChallengeId id, String title, String description) {

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/in/CreateChallengeUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/in/CreateChallengeUseCase.java
@@ -1,8 +1,8 @@
 package com.itachallenges.challengeservice.catalog.domain.port.in;
 
 import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeCommand;
-import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResult;
+import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResponse;
 
 public interface CreateChallengeUseCase {
-    CreateChallengeResult create(CreateChallengeCommand command);
+    CreateChallengeResponse create(CreateChallengeCommand command);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeId.java
@@ -3,23 +3,11 @@ package com.itachallenges.challengeservice.catalog.domain.valueobject;
 import java.util.UUID;
 
 public record ChallengeId(UUID value) {
-
     public ChallengeId {
-        if (value == null) {
-            throw new IllegalArgumentException("ChallengeId cannot be null");
-        }
+        if (value == null) throw new IllegalArgumentException("ChallengeId cannot be null");
     }
-
-    public static ChallengeId random() {
-        return new ChallengeId(UUID.randomUUID());
-    }
-
-    public static ChallengeId from(String raw) {
-        return new ChallengeId(UUID.fromString(raw));
-    }
-
+    public static ChallengeId generate() { return new ChallengeId(UUID.randomUUID()); }
+    public static ChallengeId of(String value) { return new ChallengeId(UUID.fromString(value)); }
     @Override
-    public String toString() {
-        return value.toString();
-    }
+    public String toString() { return value.toString(); }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/shared/domain/valueobject/UserId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/shared/domain/valueobject/UserId.java
@@ -6,5 +6,8 @@ public record UserId(UUID value) {
     public UserId {
         if (value == null) throw new IllegalArgumentException("UserId cannot be null");
     }
+    public static UserId generate() { return new UserId(UUID.randomUUID()); }
     public static UserId of(String value) { return new UserId(UUID.fromString(value)); }
+    @Override
+    public String toString() { return value.toString(); }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -2,7 +2,9 @@ package com.itachallenges.challengeservice.submission.application.usecase;
 
 import com.itachallenges.challengeservice.submission.application.dto.FinalizeSubmissionCommand;
 import com.itachallenges.challengeservice.submission.domain.port.in.FinalizeSubmissionUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCase {
     // TODO: inject SubmissionRepository and any other dependencies
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
@@ -2,7 +2,9 @@ package com.itachallenges.challengeservice.submission.application.usecase;
 
 import com.itachallenges.challengeservice.submission.application.dto.MarkIncompleteCommand;
 import com.itachallenges.challengeservice.submission.domain.port.in.MarkIncompleteUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class MarkIncompleteUseCaseHandler implements MarkIncompleteUseCase {
     // TODO: inject SubmissionRepository and any other dependencies
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -2,7 +2,9 @@ package com.itachallenges.challengeservice.submission.application.usecase;
 
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+import org.springframework.stereotype.Service;
 
+@Service
 public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
     // TODO: inject SubmissionRepository
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionId.java
@@ -8,4 +8,6 @@ public record SubmissionId(UUID value) {
     }
     public static SubmissionId generate() { return new SubmissionId(UUID.randomUUID()); }
     public static SubmissionId of(String value) { return new SubmissionId(UUID.fromString(value)); }
+    @Override
+    public String toString() { return value.toString(); }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleBookmarkUseCaseHandlerTest.java
@@ -1,0 +1,19 @@
+package com.itachallenges.challengeservice.activity.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class ToggleBookmarkUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate ToggleBookmarkUseCaseHandler
+
+    @Test
+    void shouldAddBookmark() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldRemoveBookmark() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/application/usecase/ToggleFavoriteUseCaseHandlerTest.java
@@ -1,0 +1,19 @@
+package com.itachallenges.challengeservice.activity.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class ToggleFavoriteUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate ToggleFavoriteUseCaseHandler
+
+    @Test
+    void shouldAddFavorite() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldRemoveFavorite() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityControllerTest.java
@@ -1,0 +1,24 @@
+package com.itachallenges.challengeservice.activity.infrastructure.adapter.in.web.controller;
+
+import org.junit.jupiter.api.Test;
+
+class ActivityControllerTest {
+
+    // TODO: setup MockMvc
+    // TODO: mock use cases
+
+    @Test
+    void shouldToggleFavorite() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldToggleBookmark() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldReturn400WhenInvalidRequest() {
+        // TODO: implement
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/controller/ChallengeControllerTest.java
@@ -2,7 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web
 
 import com.itachallenges.challengeservice.ChallengeApplication;
 import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeCommand;
-import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResult;
+import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeResponse;
 import com.itachallenges.challengeservice.catalog.domain.port.in.CreateChallengeUseCase;
 
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
@@ -37,7 +37,7 @@ class ChallengeControllerTest {
     @Test
     void shouldCreateChallenge() throws Exception {
         when(createChallengeUseCase.create(any(CreateChallengeCommand.class)))
-                .thenReturn(new CreateChallengeResult(ChallengeId.from("00000000-0000-0000-0000-000000000001")));
+                .thenReturn(new CreateChallengeResponse(ChallengeId.from("00000000-0000-0000-0000-000000000001")));
 
         mockMvc.perform(post("/api/v1/challenges")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/controller/ChallengeControllerTest.java
@@ -37,7 +37,7 @@ class ChallengeControllerTest {
     @Test
     void shouldCreateChallenge() throws Exception {
         when(createChallengeUseCase.create(any(CreateChallengeCommand.class)))
-                .thenReturn(new CreateChallengeResponse(ChallengeId.from("00000000-0000-0000-0000-000000000001")));
+                .thenReturn(new CreateChallengeResponse(ChallengeId.of("00000000-0000-0000-0000-000000000001")));
 
         mockMvc.perform(post("/api/v1/challenges")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## What does this PR do?
Adds the `activity` bounded context skeleton following the same
hexagonal architecture pattern established in `catalog` and `submission`.

## Changes
- New `activity` module with domain, application and infrastructure layers
- Aggregate `Activity` with favorite and bookmark toggles
- Domain events: `FavoriteAdded`, `FavoriteRemoved`, `BookmarkAdded`, `BookmarkRemoved`
- Use case interfaces and handlers with TODOs for students to implement
- `InMemoryActivityRepository` for local development
- `ActivityController` with endpoint placeholders
- Test skeletons with TODOs for all use cases and controller
- Renamed `CreateChallengeResult` → `CreateChallengeResponse` for consistency
- Renamed `ChallengeId.random()` → `generate()` and `from()` → `of()` for consistency

## No logic implemented
This is a skeleton PR. Business logic will be implemented by students.

## Reference
Follows the same pattern as `catalog` and `submission`. See [ADR 001](../blob/develop/backend/challenge-service/docs/adr/001-catalog-bounded-context.md) for architecture decisions.