### PR TITLE
feat: add stat bounded context skeleton

### DIFF
--- a/backend/challenge-service/README.md
+++ b/backend/challenge-service/README.md
@@ -17,6 +17,16 @@ For general architecture guidelines shared across all backend services see [`bac
 
 ---
 
+## Shared
+
+The `shared` package contains value objects used across multiple bounded contexts within this service.
+
+| Class | Description |
+|:------|:------------|
+| `UserId` | Opaque identifier for a user. Owned by `account-service`, referenced here as a value object. |
+
+---
+
 ## Architecture Decision Records
 
 | ADR | Decision |
@@ -56,13 +66,14 @@ Once a submission reaches `FINAL` or `INCOMPLETE`, the official solution of the 
 
 `ChallengeStats` maintains global counters per challenge across all users.
 
-| Counter | Description |
-|:--------|:------------|
-| `timesDone` | Total number of users who finalized the challenge |
-| `favorites` | Total number of users who marked the challenge as favorite |
-| `bookmarks` | Total number of users who bookmarked the challenge |
+| Counter       | Description                                                  |
+|:--------------|:-------------------------------------------------------------|
+| `timesDone`   | Total number of users who finalized the challenge            |
+| `favorites`   | Total number of users who marked the challenge as favorite   |
+| `bookmarks`   | Total number of users who bookmarked the challenge           |
 
 Counters are updated in the same transaction as the action that triggers them and never go below 0.
+
 ---
 
 ## Run locally

--- a/backend/challenge-service/README.md
+++ b/backend/challenge-service/README.md
@@ -13,7 +13,7 @@ For general architecture guidelines shared across all backend services see [`bac
 | `catalog` | `Challenge` | Challenge catalog management |
 | `submission` | `Submission` | User solution lifecycle |
 | `activity` | `Activity` | Favorites and bookmarks per user |
-| `stats` | `ChallengeStats` | Global counters per challenge |
+| `stat` | `ChallengeStats` | Global counters per challenge |
 
 ---
 
@@ -31,25 +31,38 @@ For general architecture guidelines shared across all backend services see [`bac
 
 A user can only have 1 submission per challenge. Once it reaches a terminal state it cannot be changed.
 
-| From         | To          | Allowed                       |
-|:-------------|:------------|:------------------------------|
-| `NONE`       | `IN_PROGRESS` | ✅ save draft               |
-| `NONE`       | `FINAL`     | ✅ finalize directly          |
-| `NONE`       | `INCOMPLETE`| ✅ mark incomplete directly   |
-| `IN_PROGRESS`| `FINAL`     | ✅                            |
-| `IN_PROGRESS`| `INCOMPLETE`| ✅                            |
-| `FINAL`      | any         | ❌ terminal state             |
-| `INCOMPLETE` | any         | ❌ terminal state             |
+| From          | To             | Allowed                      |
+|:--------------|:---------------|:-----------------------------|
+| `NONE`        | `IN_PROGRESS`  | ✅ save draft                |
+| `NONE`        | `FINAL`        | ✅ finalize directly         |
+| `NONE`        | `INCOMPLETE`   | ✅ mark incomplete directly  |
+| `IN_PROGRESS` | `FINAL`        | ✅                           |
+| `IN_PROGRESS` | `INCOMPLETE`   | ✅                           |
+| `FINAL`       | any            | ❌ terminal state            |
+| `INCOMPLETE`  | any            | ❌ terminal state            |
+
+Once a submission reaches `FINAL` or `INCOMPLETE`, the official solution of the challenge is revealed to the user.
 
 ### Activity rules
 
-| Action | Event emitted | Counter updated |
-|:-------|:-------------|:----------------|
-| Mark favorite | `FavoriteAdded` | `ChallengeStats.favorites + 1` |
-| Unmark favorite | `FavoriteRemoved` | `ChallengeStats.favorites - 1` |
-| Mark bookmark | `BookmarkAdded` | `ChallengeStats.bookmarks + 1` |
-| Unmark bookmark | `BookmarkRemoved` | `ChallengeStats.bookmarks - 1` |
+| Action          | Event emitted     | Counter updated                  |
+|:----------------|:------------------|:---------------------------------|
+| Mark favorite   | `FavoriteAdded`   | `ChallengeStats.favorites + 1`   |
+| Unmark favorite | `FavoriteRemoved` | `ChallengeStats.favorites - 1`   |
+| Mark bookmark   | `BookmarkAdded`   | `ChallengeStats.bookmarks + 1`   |
+| Unmark bookmark | `BookmarkRemoved` | `ChallengeStats.bookmarks - 1`   |
 
+### Stat rules
+
+`ChallengeStats` maintains global counters per challenge across all users.
+
+| Counter | Description |
+|:--------|:------------|
+| `timesDone` | Total number of users who finalized the challenge |
+| `favorites` | Total number of users who marked the challenge as favorite |
+| `bookmarks` | Total number of users who bookmarked the challenge |
+
+Counters are updated in the same transaction as the action that triggers them and never go below 0.
 ---
 
 ## Run locally

--- a/backend/challenge-service/docs/001-catalog-bounded-context.md
+++ b/backend/challenge-service/docs/001-catalog-bounded-context.md
@@ -18,7 +18,7 @@ We needed to decide how to organize the code internally to make it maintainable,
 
 An aggregate is a cluster of domain objects that must change together to maintain business rules consistency. It has a single entry point called the **aggregate root**, and anything that wants to modify something inside the cluster must go through it.
 
-The aggregate root is the guardian of **invariants** — rules that can never be broken. For example: a user can only have 1 FINAL submission per challenge.
+The aggregate root is the guardian of **invariants** — rules that can never be broken. For example: a user can only have 1 submission per challenge in a terminal state.
 
 An aggregate is a pure Java class with attributes and business methods. It has no knowledge of databases, frameworks or other aggregates. Persistence is handled by a Repository (infrastructure), which loads and saves the aggregate without the aggregate knowing about it.
 
@@ -31,14 +31,16 @@ We organize `challenge-service` into four internal modules, each with its own ro
 **`catalog`** — aggregate `Challenge`
 Manages the challenge catalog: statement, language, tags, difficulty, official solution and resources. Only admins can create, edit and delete challenges.
 
-**`submissions`** — aggregate `Submission`
-Manages the lifecycle of a user's solution for a challenge: IN_PROGRESS → FINAL or INCOMPLETE. Key invariant: maximum 1 FINAL per user/challenge.
+**`submission`** — aggregate `Submission`
+Manages the lifecycle of a user's solution for a challenge. A user can transition to any status directly without going through IN_PROGRESS first. Key invariant: a user can only have 1 submission per challenge, and once it reaches a terminal state (FINAL or INCOMPLETE) it cannot be changed.
 
-**`activity`** — aggregate `UserActivity`
+**`activity`** — aggregate `Activity`
 Manages user actions on a challenge: mark/unmark favorite and bookmark.
 
-**`stats`** — aggregate `ChallengeStats`
+**`stat`** — aggregate `ChallengeStats`
 Maintains global counters for a challenge: timesDone, favorites, bookmarks. Updated in the same transaction as submissions and activity.
+
+We also introduce a `shared` package for value objects used across multiple bounded contexts, such as `UserId`, which is owned by `account-service` and referenced here as an opaque identifier.
 
 ## Consequences
 
@@ -62,4 +64,4 @@ Discarded because a popular challenge could have thousands of submissions. Loadi
 Discarded because counters are updated very frequently (every favorite, every submission) while the challenge itself is rarely edited. Merging them would force loading the full statement just to increment a counter.
 
 **Move submissions to account-service**
-Discarded because the business rules of submission (max 1 FINAL, mandatory official solution) depend on the challenge, not the user. If submissions lived in account-service, it would need to call challenge-service to validate, creating write-time coupling between services.
+Discarded because the business rules of submission depend on the challenge, not the user. If submissions lived in account-service, it would need to call challenge-service to validate, creating write-time coupling between services.

--- a/backend/challenge-service/docs/001-catalog-bounded-context.md
+++ b/backend/challenge-service/docs/001-catalog-bounded-context.md
@@ -31,6 +31,9 @@ We organize `challenge-service` into four internal modules, each with its own ro
 **`catalog`** — aggregate `Challenge`
 Manages the challenge catalog: statement, language, tags, difficulty, official solution and resources. Only admins can create, edit and delete challenges.
 
+**Official solution visibility**
+The decision of whether to show the official solution is made in the application layer (`GetChallengeDetailUseCase`), not in the domain. The use case loads both `Challenge` and `Submission` aggregates and decides what to expose based on the submission status. The domain remains pure and has no knowledge of the caller context.
+
 **`submission`** — aggregate `Submission`
 Manages the lifecycle of a user's solution for a challenge. A user can transition to any status directly without going through IN_PROGRESS first. Key invariant: a user can only have 1 submission per challenge, and once it reaches a terminal state (FINAL or INCOMPLETE) it cannot be changed.
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/application/dto/ChallengeStatsResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/application/dto/ChallengeStatsResponse.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.stat.application.dto;
+
+public record ChallengeStatsResponse(
+        String challengeId,
+        long timesDone,
+        long favorites,
+        long bookmarks
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/application/usecase/GetChallengeStatsUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/application/usecase/GetChallengeStatsUseCaseHandler.java
@@ -1,0 +1,17 @@
+package com.itachallenges.challengeservice.stat.application.usecase;
+
+import com.itachallenges.challengeservice.stat.application.dto.ChallengeStatsResponse;
+import com.itachallenges.challengeservice.stat.domain.port.in.GetChallengeStatsUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GetChallengeStatsUseCaseHandler implements GetChallengeStatsUseCase {
+    // TODO: inject ChallengeStatsRepository
+
+    @Override
+    public ChallengeStatsResponse execute(String challengeId) {
+        // TODO: load ChallengeStats by challengeId
+        // TODO: return ChallengeStatsResponse
+        return null;
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/ChallengeStats.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/ChallengeStats.java
@@ -1,0 +1,46 @@
+package com.itachallenges.challengeservice.stat.domain;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.stat.domain.valueobject.ChallengeStatsId;
+
+public class ChallengeStats {
+
+    private ChallengeStatsId id;
+    private ChallengeId challengeId;
+    private long timesDone;
+    private long favorites;
+    private long bookmarks;
+
+    private ChallengeStats() {}
+
+    public static ChallengeStats create(ChallengeStatsId id, ChallengeId challengeId) {
+        // TODO: create and return a new ChallengeStats with all counters set to 0
+        return null;
+    }
+
+    public void incrementTimesDone() {
+        // TODO: increment timesDone counter
+    }
+
+    public void incrementFavorites() {
+        // TODO: increment favorites counter
+    }
+
+    public void decrementFavorites() {
+        // TODO: decrement favorites counter, never below 0
+    }
+
+    public void incrementBookmarks() {
+        // TODO: increment bookmarks counter
+    }
+
+    public void decrementBookmarks() {
+        // TODO: decrement bookmarks counter, never below 0
+    }
+
+    public ChallengeStatsId getId() { return id; }
+    public ChallengeId getChallengeId() { return challengeId; }
+    public long getTimesDone() { return timesDone; }
+    public long getFavorites() { return favorites; }
+    public long getBookmarks() { return bookmarks; }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/port/in/GetChallengeStatsUseCase.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/port/in/GetChallengeStatsUseCase.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.stat.domain.port.in;
+
+import com.itachallenges.challengeservice.stat.application.dto.ChallengeStatsResponse;
+
+public interface GetChallengeStatsUseCase {
+    ChallengeStatsResponse execute(String challengeId);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/port/out/ChallengeStatsRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/port/out/ChallengeStatsRepository.java
@@ -1,0 +1,11 @@
+package com.itachallenges.challengeservice.stat.domain.port.out;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.stat.domain.ChallengeStats;
+
+import java.util.Optional;
+
+public interface ChallengeStatsRepository {
+    ChallengeStats save(ChallengeStats stats);
+    Optional<ChallengeStats> findByChallengeId(ChallengeId challengeId);
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/valueobject/ChallengeStatsId.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/domain/valueobject/ChallengeStatsId.java
@@ -1,0 +1,14 @@
+package com.itachallenges.challengeservice.stat.domain.valueobject;
+
+import java.util.UUID;
+
+public record ChallengeStatsId(UUID value) {
+    public ChallengeStatsId {
+        if (value == null) throw new IllegalArgumentException("ChallengeStatsId cannot be null");
+    }
+    public static ChallengeStatsId generate() { return new ChallengeStatsId(UUID.randomUUID()); }
+    public static ChallengeStatsId of(String value) { return new ChallengeStatsId(UUID.fromString(value)); }
+
+    @Override
+    public String toString() { return value.toString(); }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/infrastructure/adapter/out/persistence/InMemoryChallengeStatsRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/stat/infrastructure/adapter/out/persistence/InMemoryChallengeStatsRepository.java
@@ -1,0 +1,28 @@
+package com.itachallenges.challengeservice.stat.infrastructure.adapter.out.persistence;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.stat.domain.ChallengeStats;
+import com.itachallenges.challengeservice.stat.domain.port.out.ChallengeStatsRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryChallengeStatsRepository implements ChallengeStatsRepository {
+
+    private final Map<ChallengeId, ChallengeStats> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public ChallengeStats save(ChallengeStats stats) {
+        storage.put(stats.getChallengeId(), stats);
+        return stats;
+    }
+
+    @Override
+    public Optional<ChallengeStats> findByChallengeId(ChallengeId challengeId) {
+        // TODO: find ChallengeStats by challengeId
+        return Optional.empty();
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/stat/application/usecase/GetChallengeStatsUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/stat/application/usecase/GetChallengeStatsUseCaseHandlerTest.java
@@ -1,0 +1,19 @@
+package com.itachallenges.challengeservice.stat.application.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class GetChallengeStatsUseCaseHandlerTest {
+
+    // TODO: mock dependencies
+    // TODO: instantiate GetChallengeStatsUseCaseHandler
+
+    @Test
+    void shouldReturnChallengeStats() {
+        // TODO: implement
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStatsNotFound() {
+        // TODO: implement
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Adds the `stat` bounded context skeleton following the same
hexagonal architecture pattern established in the previous modules.

## Changes
- New `stat` module with domain, application and infrastructure layers
- Aggregate `ChallengeStats` with counters: timesDone, favorites, bookmarks
- No controller — counters are returned as part of challenge detail in `catalog`
- `InMemoryChallengeStatsRepository` for local development
- Test skeletons with TODOs for students to implement

## No logic implemented
This is a skeleton PR. Business logic will be implemented by students.

## Reference
Follows the same pattern as `catalog`, `submission` and `activity`. See [ADR 001](../blob/develop/backend/challenge-service/docs/adr/001-catalog-bounded-context.md) for architecture decisions.