### PR TITLE
[CRUD] Create DTO and mapper structure for the Challenge CRUD #329

### DIFF
--- a/backend/challenge-service/build.gradle
+++ b/backend/challenge-service/build.gradle
@@ -11,9 +11,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 tasks.named('test') {

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/dto/UpdateChallengeCommand.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/dto/UpdateChallengeCommand.java
@@ -1,0 +1,5 @@
+package com.itachallenges.challengeservice.catalog.application.dto;
+
+import java.util.UUID;
+
+public record UpdateChallengeCommand(UUID id, String title, String description) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/mapper/ChallengeWebMapper.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/application/mapper/ChallengeWebMapper.java
@@ -1,0 +1,26 @@
+package com.itachallenges.challengeservice.catalog.application.mapper;
+
+import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeCommand;
+import com.itachallenges.challengeservice.catalog.application.dto.UpdateChallengeCommand;
+import com.itachallenges.challengeservice.catalog.domain.Challenge;
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto.ChallengeRequest;
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto.ChallengeResponse;
+import org.mapstruct.Mapper;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring")
+public interface ChallengeWebMapper {
+
+    CreateChallengeCommand toCreateCommand(ChallengeRequest request);
+
+    UpdateChallengeCommand toUpdateCommand(ChallengeRequest request, UUID id);
+
+    default ChallengeResponse toResponse(Challenge challenge) {
+        return new ChallengeResponse(
+                challenge.id().toString(),
+                challenge.title(),
+                challenge.description()
+        );
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/dto/ChallengeRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/dto/ChallengeRequest.java
@@ -1,0 +1,9 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChallengeRequest(
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank @Size(max = 1000) String description
+) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/dto/ChallengeResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/in/web/dto/ChallengeResponse.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto;
+
+public record ChallengeResponse(
+        String id,
+        String title,
+        String description
+) {}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/application/mapper/ChallengeWebMapperTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/application/mapper/ChallengeWebMapperTest.java
@@ -1,0 +1,68 @@
+package com.itachallenges.challengeservice.catalog.application.mapper;
+
+import com.itachallenges.challengeservice.catalog.application.dto.CreateChallengeCommand;
+import com.itachallenges.challengeservice.catalog.application.dto.UpdateChallengeCommand;
+import com.itachallenges.challengeservice.catalog.domain.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto.ChallengeRequest;
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.in.web.dto.ChallengeResponse;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChallengeWebMapperTest {
+    private static final String TITLE = "Clean Code";
+    private static final String DESCRIPTION = "Write readable code";
+
+    private final ChallengeWebMapper mapper = Mappers.getMapper(ChallengeWebMapper.class);
+
+    private static Challenge aChallenge(ChallengeId id) {
+        return Challenge.restore(id, TITLE, DESCRIPTION);
+    }
+
+    private static ChallengeRequest aRequest() {
+        return new ChallengeRequest(TITLE, DESCRIPTION);
+    }
+
+
+    @Test
+    void toResponse_shouldUnwrapChallengeId() {
+        ChallengeId id = ChallengeId.generate();
+
+        ChallengeResponse response = mapper.toResponse(aChallenge(id));
+
+        assertThat(response.id()).isEqualTo(id.toString());
+    }
+
+    @Test
+    void toResponse_shouldMapAllFields() {
+        ChallengeResponse response = mapper.toResponse(aChallenge(ChallengeId.generate()));
+
+        assertThat(response.title()).isEqualTo(TITLE);
+        assertThat(response.description()).isEqualTo(DESCRIPTION);
+    }
+
+
+    @Test
+    void toCreateCommand_shouldMapTitleAndDescription() {
+        CreateChallengeCommand command = mapper.toCreateCommand(aRequest());
+
+        assertThat(command.title()).isEqualTo(TITLE);
+        assertThat(command.description()).isEqualTo(DESCRIPTION);
+    }
+
+
+    @Test
+    void toUpdateCommand_shouldMapRequestFieldsAndPathId() {
+        UUID id = UUID.randomUUID();
+
+        UpdateChallengeCommand command = mapper.toUpdateCommand(aRequest(), id);
+
+        assertThat(command.id()).isEqualTo(id);
+        assertThat(command.title()).isEqualTo(TITLE);
+        assertThat(command.description()).isEqualTo(DESCRIPTION);
+    }
+}


### PR DESCRIPTION
## Description

Establishes the shared DTO and mapper structure for the Challenge CRUD operations.

## Changes

**New files**
- `ChallengeRequest` — shared input DTO for Create and Update, with `@NotBlank`
  and `@Size` validations via `jakarta.validation`
- `ChallengeResponse` — shared output DTO for Create, Update, Get and List
- `UpdateChallengeCommand` — application command for update operations,
  receives the path ID explicitly
- `ChallengeWebMapper` — MapStruct mapper with `toCreateCommand`, `toUpdateCommand`
  and `toResponse`. `toResponse` is implemented as a `default` method because
  `Challenge` uses fluent accessors (`id()`, `title()`, `description()`) rather
  than JavaBean convention, which MapStruct cannot resolve automatically

**Modified files**
- `CreateChallengeCommand` — cleaned up formatting, no logic change
- `build.gradle` — added MapStruct `implementation` and `annotationProcessor`

**Tests**
- `ChallengeWebMapperTest` — covers all three mapper methods, including
  `ChallengeId` unwrapping via `challenge.id().toString()` in `toResponse`

## Deviations from issue
- `@Mapping(source = "id.value", target = "id")` replaced by `default` method —
  `Challenge` uses fluent accessors, not JavaBean convention
- `CreateChallengeRequest` and `CreateChallengeResponse` not deleted —
  still referenced by the existing controller. Removal and `toCommand()`
  cleanup tracked as technical debt

## Not included
- `ChallengeRequestValidationTest` — deferred, validations are declarative
  and low-risk for MVP

## How to test
```bash
./gradlew :challenge-service:build
```