### PR TITLE
feat(auth): configure auth routes through gateway (#369)

### DIFF
--- a/infra/gateway/nginx.conf
+++ b/infra/gateway/nginx.conf
@@ -2,6 +2,23 @@ server {
   listen 80;
   server_name _;
 
+  # GITHUB AUTH
+  location /oauth2/ {
+    proxy_pass http://account-service:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  location /login/oauth2/ {
+    proxy_pass http://account-service:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
   # USERS
   location /itachallenge/api/v1/users {
     proxy_pass http://account-service:8080/api/v1/users;

--- a/infra/gateway/nginx.conf
+++ b/infra/gateway/nginx.conf
@@ -2,16 +2,8 @@ server {
   listen 80;
   server_name _;
 
-  # GITHUB AUTH
-  location /oauth2/ {
-    proxy_pass http://account-service:8080;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
-
-  location /login/oauth2/ {
+  # ACCOUNT
+  location /api/account/ {
     proxy_pass http://account-service:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Host $host;
@@ -20,7 +12,7 @@ server {
   }
 
   # USERS
-  location /itachallenge/api/v1/users {
+  location itachallenge/api/v1/users {
     proxy_pass http://account-service:8080/api/v1/users;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infra/gateway/nginx.conf
+++ b/infra/gateway/nginx.conf
@@ -12,7 +12,7 @@ server {
   }
 
   # USERS
-  location itachallenge/api/v1/users {
+  location /itachallenge/api/v1/users {
     proxy_pass http://account-service:8080/api/v1/users;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Definition

Update the gateway configuration so account-service routes follow the new public `/api/account/*` prefix.

## Acceptance Criteria

- Account routes are accessible through the gateway
- Account-service is reachable for the authentication flow
- The routing was manually tested in the local environment and validated with the expected account routes

<img width="998" height="551" alt="Captura de pantalla 2026-04-24 a las 15 49 52" src="https://github.com/user-attachments/assets/6e9712f6-b57d-420f-b8f3-fd6aa219c1ea" />
