### PR TITLE
feat: add delete method signature to ChallengeRepository port

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -1,4 +1,5 @@
 package com.itachallenges.challengeservice.catalog.domain.port.out;
 
 public interface ChallengeRepository {
+    void delete(String id);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -6,5 +6,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryChallengeRepository implements ChallengeRepository {
-
+    @Override
+    public void delete(String id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -1,0 +1,15 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.out.persistence;
+
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence.InMemoryChallengeRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InMemoryChallengeRepositoryTest {
+
+    @Test
+    void delete_shouldThrowUnsupportedOperationException() {
+        InMemoryChallengeRepository repository = new InMemoryChallengeRepository();
+        assertThrows(UnsupportedOperationException.class, () -> repository.delete("any-id"));
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -1,6 +1,5 @@
-package com.itachallenges.challengeservice.catalog.infrastructure.adapter.out.persistence;
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
-import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence.InMemoryChallengeRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
Main goal: defining the out port interface in Domain for deleting a challenge.

Files changed:
-ChallengeRepository
-InMemoryChallengeRepository (override method with provisional exception before implementing the final logic in a subsequent PR)

