### PR TITLE
feat(auth): implement auth service with mock (#345)

### DIFF
--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -4,9 +4,9 @@ import { firstValueFrom } from 'rxjs';
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
 
-const mockUser: AuthUser = {
-  username: 'JordiMiravet',
-  avatarUrl: 'https://github.com/JordiMiravet.png',
+const MOCK_USER: AuthUser = {
+  username: 'MockUser',
+  avatarUrl: 'https://github.com/MockUser.png',
 };
 
 describe('AuthService', () => {
@@ -29,13 +29,13 @@ describe('AuthService', () => {
   });
 
   it('should return current user when getUser is called', () => {
-    service.setUser(mockUser);
-    expect(getUser()).toEqual(mockUser);
+    service.setUser(MOCK_USER);
+    expect(getUser()).toEqual(MOCK_USER);
   });
 
   it('should return mock user when loginWithGithub is called', async () => {
     const result = await firstValueFrom(service.loginWithGithub());
-    expect(result).toEqual(mockUser);
+    expect(result).toEqual(MOCK_USER);
   });
 
   it('should not modify user signal when loginWithGithub is called', () => {

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -1,19 +1,23 @@
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
 
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
 
 const mockUser: AuthUser = {
   username: 'JordiMiravet',
-  avatarUrl: 'url-123',
+  avatarUrl: 'https://github.com/JordiMiravet.png',
 };
 
 describe('AuthService', () => {
   let service: AuthService;
+  let getUser: () => AuthUser | null;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(AuthService);
+
+    getUser = () => service.user();
   });
 
   it('should be created', () => {
@@ -21,22 +25,21 @@ describe('AuthService', () => {
   });
 
   it('should initialize user as null', () => {
-    expect(service.user()).toBe(null);
-  });
-
-  it('should set user when setUser is called', () => {
-      service.setUser(mockUser);
-      expect(service.user()).toEqual(mockUser);
+    expect(getUser()).toBeNull();
   });
 
   it('should return current user when getUser is called', () => {
     service.setUser(mockUser);
-    expect(service.getUser()).toEqual(mockUser);
+    expect(getUser()).toEqual(mockUser);
   });
 
-  it('should return an observable from loginWithGithub', () => {
-    const result = service.loginWithGithub();
-    expect(result).toBeTruthy();
+  it('should return mock user when loginWithGithub is called', async () => {
+    const result = await firstValueFrom(service.loginWithGithub());
+    expect(result).toEqual(mockUser);
   });
-  
+
+  it('should not modify user signal when loginWithGithub is called', () => {
+    service.loginWithGithub().subscribe();
+    expect(getUser()).toBeNull();
+  });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { AuthUser } from '../models/auth-user.model';
-import { EMPTY, Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -9,7 +9,12 @@ export class AuthService {
   user = signal<AuthUser | null>(null);
 
   loginWithGithub(): Observable<AuthUser> {
-    return EMPTY;
+    const user: AuthUser = {
+      username: 'JordiMiravet',
+      avatarUrl: 'https://github.com/JordiMiravet.png',
+    };
+
+    return of(user);
   }
 
   setUser(user: AuthUser): void {

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -9,12 +9,12 @@ export class AuthService {
   user = signal<AuthUser | null>(null);
 
   loginWithGithub(): Observable<AuthUser> {
-    const user: AuthUser = {
-      username: 'JordiMiravet',
-      avatarUrl: 'https://github.com/JordiMiravet.png',
+    const MOCK_USER: AuthUser = {
+      username: 'MockUser',
+      avatarUrl: 'https://github.com/MockUser.png',
     };
 
-    return of(user);
+    return of(MOCK_USER);
   }
 
   setUser(user: AuthUser): void {


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/345)

## Summary
Added a simple mock implementation in `AuthService` to simulate GitHub login and support testing.

## What's included
- Mock `loginWithGithub()` returning a static user
- Unit tests for service behavior