### PR TITLE
feat(challenge-service): implement loadall logic in service (#395)

### DIFF
--- a/frontend/src/app/features/challenges/models/challenges.mock.ts
+++ b/frontend/src/app/features/challenges/models/challenges.mock.ts
@@ -1,0 +1,19 @@
+import { IChallenge } from './ichallenge.interface';
+
+export const CHALLENGES_MOCK: IChallenge[] = [
+  {
+    id: "1",
+    title: "primer",
+    description: "descripció 1"
+  },
+  {
+    id: "2",
+    title: "segon",
+    description: "descripció 2"
+  },
+  {
+    id: "3",
+    title: "tercer",
+    description: "descripció 3"
+  },
+];

--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -7,7 +7,7 @@ import { CHALLENGES_MOCK } from '../models/challenges.mock';
 
 describe('ChallengeService', () => {
   let service: ChallengeService;
-  let mockChallengeApiService: any;
+  let mockChallengeApiService: Partial<ChallengeApiService>;
 
   beforeEach(() => {
     mockChallengeApiService = {

--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -1,16 +1,36 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { ChallengeService } from './challenge.service';
+import { ChallengeApiService } from '../data-access/challenge-api.service';
+import { CHALLENGES_MOCK } from '../models/challenges.mock';
 
 describe('ChallengeService', () => {
   let service: ChallengeService;
+  let mockChallengeApiService: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    mockChallengeApiService = {
+      loadAll: () => of(CHALLENGES_MOCK)
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ChallengeApiService, useValue: mockChallengeApiService }
+      ]
+    });
     service = TestBed.inject(ChallengeService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should return challenges from loadAll', () => {
+    let result: any;
+    service.loadAll().subscribe((challenges) => {
+      result = challenges;
+    });
+    expect(result).toEqual(CHALLENGES_MOCK);
   });
 });

--- a/frontend/src/app/features/challenges/services/challenge.service.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { IChallengeRequest } from '../models/ichallenge-request.interface';
 import { IChallenge } from '../models/ichallenge.interface';
 import { Observable, of } from 'rxjs';
+import { ChallengeApiService } from '../data-access/challenge-api.service';
 
 @Injectable({
   providedIn: 'root',
 })
 
 export class ChallengeService {
+
+  challengeApiService = inject(ChallengeApiService)
   
   create(challenge: IChallengeRequest): Observable<IChallenge>  { 
     return of ({
@@ -18,7 +21,7 @@ export class ChallengeService {
   }
 
   loadAll(): Observable<IChallenge[]> {
-    return of ([])
+    return this.challengeApiService.loadAll();
   }
 
   update(id: string, challenge: IChallengeRequest): Observable<IChallenge> { 


### PR DESCRIPTION
 Base issue: **#395**

## Goal

Connect `ChallengeService.loadAll()` with `ChallengeAPIService.loadAll()`.

## What has been done

* **Mocking:** Created `challenges.mock` for testing purposes.
* **Logic:** Added a call from `loadAll()` in `ChallengeService` to `ChallengeAPIService`.
* **Testing:** Implemented unit tests for the new logic.

## What has NOT been done

* **API connection:** It requires previous configuration and the endpoint base URL.