### PR TITLE
feat(delete-challenge-page): create delete challenge page (#367)

### DIFF
--- a/frontend/src/app/features/challenges/challenges.routes.ts
+++ b/frontend/src/app/features/challenges/challenges.routes.ts
@@ -1,11 +1,16 @@
 import { Routes } from '@angular/router';
 import { ChallengesListPage } from './pages/challenges-list-page.component';
 import { ChallengeDetailPage } from './pages/challenge-detail-page.component';
+import { DeleteChallengePage } from './pages/delete-challenge-page/delete-challenge-page';
 
 export const CHALLENGES_ROUTES: Routes = [
   {
     path: '',
     component: ChallengesListPage,
+  },
+  {
+    path: 'delete',
+    component: DeleteChallengePage,
   },
   {
     path: ':id',

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.html
@@ -1,1 +1,10 @@
-<p>delete-challenge-page works!</p>
+<h1>Esborrar Repte</h1>
+
+<form [formGroup]="deleteChallengeForm" (ngSubmit)="onSubmit()">
+    <div>
+        <label for="challengeId">ID del repte</label>
+        <input type="text" id="challengeId" formControlName="challengeId">
+    </div>
+    
+    <button type="submit">Eliminar repte</button>
+</form>

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.html
@@ -1,0 +1,1 @@
+<p>delete-challenge-page works!</p>

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
@@ -1,14 +1,29 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DeleteChallengePage } from './delete-challenge-page';
+import { ChallengeService } from '../../services/challenge.service';
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
 
 describe('DeleteChallengePage', () => {
   let component: DeleteChallengePage;
   let fixture: ComponentFixture<DeleteChallengePage>;
+  let mockChallengeService: any;
+  let mockRouter: any;
 
   beforeEach(async () => {
+    mockChallengeService = {
+      delete: (id: string) => of({ success: true})
+    };
+    mockRouter = {
+      navigate: vi.fn()
+    };
     await TestBed.configureTestingModule({
-      imports: [DeleteChallengePage]
+      imports: [DeleteChallengePage],
+      providers: [
+        { provide: ChallengeService, useValue: mockChallengeService},
+        { provide: Router, useValue: mockRouter }
+      ]
     })
     .compileComponents();
 
@@ -20,4 +35,41 @@ describe('DeleteChallengePage', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should start the form with empty field', () => {
+    const id = component.deleteChallengeForm.get('challengeId')
+    
+    expect(id?.value).toBe('')
+  })
+
+  it('should call onSubmit when form is submitted', () => {
+    vi.spyOn(component, 'onSubmit')
+
+    const form = fixture.nativeElement.querySelector('form')
+    form.dispatchEvent(new Event('submit'));
+    
+    expect(component.onSubmit).toHaveBeenCalled();
+  })
+
+  it('should call challengeService.delete when call OnSubmit with correct challengeId', () => {
+    const testId = '123'
+    component.deleteChallengeForm.setValue({challengeId: testId})
+
+    vi.spyOn(mockChallengeService, 'delete').mockReturnValue(of({success: true}))
+
+    component.onSubmit()
+    expect(mockChallengeService.delete).toHaveBeenCalledWith(testId);
+  })
+
+  it('should call goChallenges when call onSubmit', () => {
+    vi.spyOn(component, 'goChallenges')
+
+    component.onSubmit()
+    expect(component.goChallenges).toHaveBeenCalled();
+  })
+
+  it('should navigate when call goChallenges', () => {
+    component.goChallenges()
+    expect(mockRouter.navigate).toHaveBeenCalled();
+  })
 });

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
@@ -8,15 +8,15 @@ import { Router } from '@angular/router';
 describe('DeleteChallengePage', () => {
   let component: DeleteChallengePage;
   let fixture: ComponentFixture<DeleteChallengePage>;
-  let mockChallengeService: any;
-  let mockRouter: any;
+  let mockChallengeService: Partial<ChallengeService>;
+  let mockRouter: Partial<Router>;
 
   beforeEach(async () => {
     mockChallengeService = {
-      delete: (id: string) => of({ success: true})
+      delete: (id: string) => of(undefined)
     };
     mockRouter = {
-      navigate: vi.fn()
+      navigate: vi.fn() as any
     };
     await TestBed.configureTestingModule({
       imports: [DeleteChallengePage],
@@ -55,7 +55,7 @@ describe('DeleteChallengePage', () => {
     const testId = '123'
     component.deleteChallengeForm.setValue({challengeId: testId})
 
-    vi.spyOn(mockChallengeService, 'delete').mockReturnValue(of({success: true}))
+    vi.spyOn(mockChallengeService, 'delete').mockReturnValue(of(undefined))
 
     component.onSubmit()
     expect(mockChallengeService.delete).toHaveBeenCalledWith(testId);

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteChallengePage } from './delete-challenge-page';
+
+describe('DeleteChallengePage', () => {
+  let component: DeleteChallengePage;
+  let fixture: ComponentFixture<DeleteChallengePage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeleteChallengePage]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeleteChallengePage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ChallengeService } from '../../services/challenge.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-delete-challenge-page',
@@ -11,7 +12,8 @@ import { ChallengeService } from '../../services/challenge.service';
 export class DeleteChallengePage {
 
   readonly fb = inject(FormBuilder);
-  challengeService = inject(ChallengeService)
+  readonly challengeService = inject(ChallengeService)
+  readonly router = inject(Router)
 
   deleteChallengeForm = this.fb.group({
     challengeId: ['']
@@ -20,9 +22,14 @@ export class DeleteChallengePage {
   onSubmit(){
     const challengeId = this.deleteChallengeForm.value.challengeId ?? ''
     this.challengeService.delete(challengeId).subscribe({
-      next(value) {
-        console.log("OK")
+      next: (value) => {
+        this.goChallenges()    
       },
     })
   }
+
+  goChallenges(){
+    this.router.navigate(['/challenges/'])
+  }
+
 }

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
@@ -1,11 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-delete-challenge-page',
-  imports: [],
+  imports: [ReactiveFormsModule],
   templateUrl: './delete-challenge-page.html',
   styleUrl: './delete-challenge-page.css',
 })
 export class DeleteChallengePage {
 
+  readonly fb = inject(FormBuilder);
+
+  deleteChallengeForm = this.fb.group({
+    challengeId: ['']
+  })
+
+  onSubmit(){
+    const challengeId = this.deleteChallengeForm.value.challengeId
+    console.log(challengeId)
+  }
 }

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
@@ -1,5 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ChallengeService } from '../../services/challenge.service';
 
 @Component({
   selector: 'app-delete-challenge-page',
@@ -10,13 +11,18 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 export class DeleteChallengePage {
 
   readonly fb = inject(FormBuilder);
+  challengeService = inject(ChallengeService)
 
   deleteChallengeForm = this.fb.group({
     challengeId: ['']
   })
 
   onSubmit(){
-    const challengeId = this.deleteChallengeForm.value.challengeId
-    console.log(challengeId)
+    const challengeId = this.deleteChallengeForm.value.challengeId ?? ''
+    this.challengeService.delete(challengeId).subscribe({
+      next(value) {
+        console.log("OK")
+      },
+    })
   }
 }

--- a/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/delete-challenge-page/delete-challenge-page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-challenge-page',
+  imports: [],
+  templateUrl: './delete-challenge-page.html',
+  styleUrl: './delete-challenge-page.css',
+})
+export class DeleteChallengePage {
+
+}


### PR DESCRIPTION
 Base issue: **#367**

## Goal

Create the `delete-challenge-page` component to delete a challenge.

## What has been done

* **Component Creation:** Developed the `delete-challenge-page` component.
* **UI/UX:** Implemented the basic screen design with a form.
* **Service Integration:** Injected and utilized the `ChallengeService`.
* **Navigation:** Managed routing and redirects using the `Router` service.
* **Testing:** Implemented unit tests for the new logic.