### PR TITLE
feat(challenge-service): delete function to remove challenge (#368)

### DIFF
--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -1,16 +1,40 @@
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { ChallengeService } from './challenge.service';
+import { ChallengeApiService } from '../data-access/challenge-api.service';
 
 describe('ChallengeService', () => {
   let service: ChallengeService;
+  let mockChallengeApiService: Partial<ChallengeApiService>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    mockChallengeApiService = {
+      delete: (id: string) => of(undefined)
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ChallengeApiService, useValue: mockChallengeApiService }
+      ]
+    });
     service = TestBed.inject(ChallengeService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('delete', () => {
+    it('should call challengeApiService.delete with the correct id and return its observable', () => {
+      const testId = '123';
+      const expectedObservable = of(undefined);
+      vi.spyOn(mockChallengeApiService, 'delete').mockReturnValue(expectedObservable);
+
+      const result = service.delete(testId);
+
+      expect(mockChallengeApiService.delete).toHaveBeenCalledWith(testId);
+      expect(result).toBe(expectedObservable);
+    });
   });
 });

--- a/frontend/src/app/features/challenges/services/challenge.service.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { IChallengeRequest } from '../models/ichallenge-request.interface';
 import { IChallenge } from '../models/ichallenge.interface';
 import { Observable, of } from 'rxjs';
+import { ChallengeApiService } from '../data-access/challenge-api.service';
 
 @Injectable({
   providedIn: 'root',
@@ -9,6 +10,8 @@ import { Observable, of } from 'rxjs';
 
 export class ChallengeService {
   
+  challengeApiService = inject(ChallengeApiService)
+
   create(challenge: IChallengeRequest): Observable<IChallenge>  { 
     return of ({
       id: "1",
@@ -29,6 +32,6 @@ export class ChallengeService {
     })
   }
 
-  delete(id: string): Observable<void> { return of(undefined) }
+  delete(id: string): Observable<void> { return this.challengeApiService.delete(id) }
 
 }

--- a/frontend/src/app/features/challenges/services/challenge.service.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.ts
@@ -12,8 +12,6 @@ export class ChallengeService {
 
   challengeApiService = inject(ChallengeApiService)
   
-  challengeApiService = inject(ChallengeApiService)
-
   create(challenge: IChallengeRequest): Observable<IChallenge>  { 
     return of ({
       id: "1",


### PR DESCRIPTION
 Base issue: **#368**

## Goal

Connect `ChallengeService.delete()` with `ChallengeAPIService.delete()`.

## What has been done

* **Logic:** Added a call from `delete()` in `ChallengeService` to `ChallengeAPIService`.
* **Testing:** Implemented unit tests for the new logic.

## What has NOT been done

* **API connection:** It requires previous configuration and the endpoint base URL.