### PR TITLE
[Update] Define updateChallenge method in domain output port

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -1,5 +1,10 @@
 package com.itachallenges.challengeservice.catalog.domain.port.out;
 
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+
 public interface ChallengeRepository {
+
+    Challenge update(Challenge challenge);
+
     void delete(String id);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -4,5 +4,5 @@ import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 
 public interface ChallengeRepository {
 
-    Challenge updateChallenge(Challenge challenge);
+    Challenge update(Challenge challenge);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -1,4 +1,8 @@
 package com.itachallenges.challengeservice.catalog.domain.port.out;
 
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+
 public interface ChallengeRepository {
+
+    Challenge updateChallenge(Challenge challenge);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -1,10 +1,16 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public class InMemoryChallengeRepository implements ChallengeRepository {
+
+    @Override
+    public Challenge updateChallenge(Challenge challenge) {
+        throw new UnsupportedOperationException("To be implemented");
+    }
 
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 public class InMemoryChallengeRepository implements ChallengeRepository {
 
     @Override
-    public Challenge updateChallenge(Challenge challenge) {
+    public Challenge update(Challenge challenge) {
         throw new UnsupportedOperationException("To be implemented");
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -1,11 +1,18 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
 public class InMemoryChallengeRepository implements ChallengeRepository {
+
+    @Override
+    public Challenge update(Challenge challenge) {
+        throw new UnsupportedOperationException("To be implemented");
+    }
+
     @Override
     public void delete(String id) {
         throw new UnsupportedOperationException("Not implemented yet");

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -7,6 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class InMemoryChallengeRepositoryTest {
 
     @Test
+    void update_shouldThrowUnsupportedOperationException() {
+        InMemoryChallengeRepository repository = new InMemoryChallengeRepository();
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> repository.update(null)
+        );
+    }
+
+    @Test
     void delete_shouldThrowUnsupportedOperationException() {
         InMemoryChallengeRepository repository = new InMemoryChallengeRepository();
         assertThrows(UnsupportedOperationException.class, () -> repository.delete("any-id"));


### PR DESCRIPTION
Defined the updateChallenge method to update an existing challenge.

---

Changes
-ChallengeRepository: defined updateChallenge method.
-InMemoryChallengeRepository: added placeholder empty implementation.

---

Implementation details

The actual logic for updating a challenge will be handled in a subsequent task.