### PR TITLE
feat: add temporary findAll endpoint to ChallengeController

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class ChallengeController {
 
     @GetMapping
-    public ResponseEntity<List<ChallengeResponse>> findAllChallenges() {
+    public ResponseEntity<List<ChallengeResponse>> findAll() {
         return ResponseEntity.ok(List.of());
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -7,9 +7,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/challenge")
 public class ChallengeController {
+
+    @GetMapping
+    public ResponseEntity<List<ChallengeResponse>> findAllChallenges() {
+        return ResponseEntity.ok(List.of());
+    }
 
     @PostMapping
     public ResponseEntity<ChallengeResponse> create(@RequestBody ChallengeRequest request) {

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -27,8 +28,15 @@ class ChallengeControllerTest {
     );
 
     @Test
+    void should_return_200_with_empty_list_when_requesting_all_challenges() throws Exception {
+        mockMvc.perform(get("/api/challenge"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+
+    @Test
     void should_return_201_with_challenge_when_valid_request() throws Exception {
-        mockMvc.perform(post("/challenge")
+        mockMvc.perform(post("/api/challenge")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())


### PR DESCRIPTION
## Summary
- add a temporary `GET /api/challenge` endpoint in `ChallengeController`
- return an empty list of `ChallengeResponse`
- add controller test for the new endpoint
- align the existing create test path with the current controller mapping

## Notes
- this PR does not integrate with repository or adapter layers yet
- the existing controller test was pointing to `/challenge` while the controller is mapped to `/api/challenge`
- this small test adjustment is included so controller tests pass consistently
- endpoint/path conventions can be revisited in the closing PR if needed

Closes #333

Just to keep the habit, I’m adding a screenshot.

Validation: `./gradlew :challenge-service:test --tests '*ChallengeControllerTest'` passed, and manual Postman check for `GET /api/challenge` returned `200 OK` with `[]`.

<img width="1241" height="949" alt="Postman FindAll" src="https://github.com/user-attachments/assets/c97fcb06-54f1-4b3f-a9ac-493263e1a9d1" />

Test:
<img width="1827" height="1318" alt="Test FindAll" src="https://github.com/user-attachments/assets/4e7031b0-613d-4335-a705-e497eff015ab" />

