### PR TITLE
feat(auth): add auth guard for protected routes (#349)

### DIFF
--- a/frontend/src/app/core/guards/auth-guard.spec.ts
+++ b/frontend/src/app/core/guards/auth-guard.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { authGuard } from './auth-guard';
+import { AuthService } from '../../features/auth/data-access/auth-service';
+import { AuthUser } from '../../features/auth/models/auth-user.model';
+
+const MOCK_USER: AuthUser = {
+  username: 'MockUser',
+  avatarUrl: 'https://github.com/MockUser.png',
+};
+
+describe('authGuard', () => {
+  let authService: AuthService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: Router,
+          useValue: { navigate: vi.fn() },
+        },
+      ],
+    });
+
+    authService = TestBed.inject(AuthService);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow navigation when user is authenticated', () => {
+    authService.setUser(MOCK_USER);
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to /auth when no user is authenticated', () => {
+    const result = TestBed.runInInjectionContext(() => authGuard({} as any, {} as any));
+
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/auth']);
+  });
+});

--- a/frontend/src/app/core/guards/auth-guard.ts
+++ b/frontend/src/app/core/guards/auth-guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../../features/auth/data-access/auth-service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.getUser()) return true;
+
+  router.navigate(['/auth']);
+  return false;
+};

--- a/frontend/src/app/features/profile/profile.routes.ts
+++ b/frontend/src/app/features/profile/profile.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
 import { ProfilePage } from './pages/profile-page.component';
+import { authGuard } from '../../core/guards/auth-guard';
 
 export const PROFILE_ROUTES: Routes = [
   {
     path: '',
     component: ProfilePage,
+    canActivate: [authGuard],
   },
 ];

--- a/frontend/src/app/features/profile/profile.routes.ts
+++ b/frontend/src/app/features/profile/profile.routes.ts
@@ -1,11 +1,11 @@
 import { Routes } from '@angular/router';
-import { ProfilePage } from './pages/profile-page.component';
+import { ProfilePageComponent } from './pages/profile-page/profile-page';
 import { authGuard } from '../../core/guards/auth-guard';
 
 export const PROFILE_ROUTES: Routes = [
   {
     path: '',
-    component: ProfilePage,
+    component: ProfilePageComponent,
     canActivate: [authGuard],
   },
 ];


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/349)

## Summary
Added auth guard to protect the `/profile` route, redirecting unauthenticated users to `/auth`

## What's included
- `authGuard` created in `core/guards/`
- Guard applied to `/profile` route in `profile.routes.ts`
- Unit tests covering both authenticated and unauthenticated cases

## Notes
Only `/profile` is protected for now to avoid affecting other team members' routes. Other routes can be protected incrementally as the auth flow matures.