### PR TITLE
test(app): remove unused default title test

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -13,11 +13,4 @@ describe('App', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-
-  it('should render title', async () => {
-    const fixture = TestBed.createComponent(App);
-    await fixture.whenStable();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, frontend');
-  });
 });


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/417)

## Summary
Removed the default `should render title` test, which was failing because the App component no longer renders an `h1` with the default title.

## Notes
The `should create the app` test is kept as it still validates the component instantiation correctly.