### PR TITLE
refactor(auth): switch to GitHub OAuth login flow (#350)

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -2,10 +2,12 @@ import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/
 import { provideRouter } from '@angular/router';
 
 import { appRoutes } from './app.routes';
+import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
-    provideRouter(appRoutes)
+    provideRouter(appRoutes),
+    provideHttpClient(),
   ]
 };

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -1,34 +1,20 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
-import { vi } from 'vitest';
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
+import { firstValueFrom } from 'rxjs';
 
 const MOCK_USER: AuthUser = {
-  username: 'MockUser',
+  username: 'mockUser',
   avatarUrl: 'https://github.com/MockUser.png',
+  token: 'token-808',
 };
 
 describe('AuthService', () => {
   let service: AuthService;
-  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        provideHttpClient(),
-        provideHttpClientTesting(),
-      ],
-    });
-
+    TestBed.configureTestingModule({});
     service = TestBed.inject(AuthService);
-    httpMock = TestBed.inject(HttpTestingController);
-  });
-
-  afterEach(() => {
-    httpMock.verify();
   });
 
   it('should be created', () => {
@@ -45,32 +31,22 @@ describe('AuthService', () => {
     expect(service.getUser()).toEqual(MOCK_USER);
   });
 
-  it('should redirect to github when loginWithGithub is called', () => {
+  it('should set mock user and redirect to profile when loginWithGithub is called', () => {
     const originalLocation = globalThis.location;
     const locationMock = { href: '' };
+
     vi.stubGlobal('location', locationMock);
 
     service.loginWithGithub();
 
-    expect(locationMock.href).toBe('/api/account/oauth2/authorization/github');
+    expect(service.user()).toEqual(MOCK_USER);
+    expect(locationMock.href).toBe('/profile');
 
     vi.stubGlobal('location', originalLocation);
   });
 
-  it('should not modify user signal when loginWithGithub is called', () => {
-    service.loginWithGithub();
-    expect(service.user()).toBeNull();
-  });
-
-  it('should fetch user from API', async () => {
-    const promise = firstValueFrom(service.fetchUser());
-
-    const req = httpMock.expectOne('/api/account/user/me');
-    expect(req.request.method).toBe('GET');
-    expect(req.request.withCredentials).toBe(true);
-    req.flush(MOCK_USER);
-
-    const result = await promise;
+  it('should fetch mock user', async () => {
+    const result = await firstValueFrom(service.fetchUser());
     expect(result).toEqual(MOCK_USER);
   });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-
+import { vi } from 'vitest';
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
 
@@ -11,35 +13,64 @@ const MOCK_USER: AuthUser = {
 
 describe('AuthService', () => {
   let service: AuthService;
-  let getUser: () => AuthUser | null;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(AuthService);
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
 
-    getUser = () => service.user();
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should initialize user as null', () => {
-    expect(getUser()).toBeNull();
+  it('should start with null user', () => {
+    expect(service.user()).toBeNull();
   });
 
-  it('should return current user when getUser is called', () => {
+  it('should set and get user correctly', () => {
     service.setUser(MOCK_USER);
-    expect(getUser()).toEqual(MOCK_USER);
+    expect(service.user()).toEqual(MOCK_USER);
+    expect(service.getUser()).toEqual(MOCK_USER);
   });
 
-  it('should return mock user when loginWithGithub is called', async () => {
-    const result = await firstValueFrom(service.loginWithGithub());
-    expect(result).toEqual(MOCK_USER);
+  it('should redirect to github when loginWithGithub is called', () => {
+    const originalLocation = globalThis.location;
+    const locationMock = { href: '' };
+    vi.stubGlobal('location', locationMock);
+
+    service.loginWithGithub();
+
+    expect(locationMock.href).toBe('/api/account/oauth2/authorization/github');
+
+    vi.stubGlobal('location', originalLocation);
   });
 
   it('should not modify user signal when loginWithGithub is called', () => {
-    service.loginWithGithub().subscribe();
-    expect(getUser()).toBeNull();
+    service.loginWithGithub();
+    expect(service.user()).toBeNull();
+  });
+
+  it('should fetch user from API', async () => {
+    const promise = firstValueFrom(service.fetchUser());
+
+    const req = httpMock.expectOne('/api/account/user/me');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.withCredentials).toBe(true);
+    req.flush(MOCK_USER);
+
+    const result = await promise;
+    expect(result).toEqual(MOCK_USER);
   });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
-import { firstValueFrom } from 'rxjs';
 
 const MOCK_USER: AuthUser = {
   username: 'mockUser',

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,20 +1,25 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
-import { Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
+  private readonly http = inject(HttpClient);
   user = signal<AuthUser | null>(null);
 
-  loginWithGithub(): Observable<AuthUser> {
-    const MOCK_USER: AuthUser = {
-      username: 'MockUser',
-      avatarUrl: 'https://github.com/MockUser.png',
-    };
+  private readonly URL = '/api/account/oauth2/authorization/github';
 
-    return of(MOCK_USER);
+  loginWithGithub(): void {
+    globalThis.location.href = this.URL
+  }
+
+  fetchUser(): Observable<AuthUser> {
+    return this.http.get<AuthUser>('/api/account/user/me', {
+      withCredentials: true
+    });
   }
 
   setUser(user: AuthUser): void {
@@ -24,5 +29,4 @@ export class AuthService {
   getUser(): AuthUser | null {
     return this.user();
   }
-
 }

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -13,7 +13,7 @@ export class AuthService {
   private readonly URL = '/api/account/oauth2/authorization/github';
 
   loginWithGithub(): void {
-    globalThis.location.href = this.URL
+    globalThis.location.href = this.URL;
   }
 
   fetchUser(): Observable<AuthUser> {

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
 
@@ -8,18 +8,23 @@ import { AuthUser } from '../models/auth-user.model';
 })
 export class AuthService {
   private readonly http = inject(HttpClient);
+
   user = signal<AuthUser | null>(null);
 
-  private readonly URL = '/api/account/oauth2/authorization/github';
+  private readonly mockUser: AuthUser = {
+    username: 'mockUser',
+    avatarUrl: 'https://github.com/MockUser.png',
+    token: 'token-808'
+  };
 
   loginWithGithub(): void {
-    globalThis.location.href = this.URL;
+    this.setUser(this.mockUser);
+
+    globalThis.location.href = '/profile';
   }
 
   fetchUser(): Observable<AuthUser> {
-    return this.http.get<AuthUser>('/api/account/user/me', {
-      withCredentials: true
-    });
+    return of(this.mockUser);
   }
 
   setUser(user: AuthUser): void {

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.html
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.html
@@ -8,9 +8,4 @@
             <span>Login with GitHub</span>
         }
     </button>
-
-    @if (error()) {
-        <p class="auth__error">Login failed. Try again.</p>
-    }
-    
 </section>

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
@@ -17,9 +17,9 @@ describe('AuthPageComponent', () => {
     await TestBed.configureTestingModule({
       imports: [AuthPageComponent],
       providers: [
-        {
-          provide: AuthService,
-          useValue: authServiceMock,
+        { 
+          provide: AuthService, 
+          useValue: authServiceMock 
         },
       ],
     }).compileComponents();

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
@@ -1,43 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AuthPageComponent } from './auth-page';
 import { AuthService } from '../../data-access/auth-service';
-import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
-import { Router } from '@angular/router';
 
 describe('AuthPageComponent', () => {
   let component: AuthPageComponent;
   let fixture: ComponentFixture<AuthPageComponent>;
 
-  let router: Router;
-  let navigateSpy: ReturnType<typeof vi.spyOn>;
-
   const authServiceMock = {
     loginWithGithub: vi.fn(),
-    setUser: vi.fn(),
-  };
-
-  const MOCK_USER = { 
-    username: 'MockUser', 
-    avatarUrl: 'https://github.com/MockUser.png' 
   };
 
   beforeEach(async () => {
+    authServiceMock.loginWithGithub.mockReset();
+
     await TestBed.configureTestingModule({
       imports: [AuthPageComponent],
       providers: [
-        { 
-          provide: AuthService, 
-          useValue: authServiceMock 
+        {
+          provide: AuthService,
+          useValue: authServiceMock,
         },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AuthPageComponent);
     component = fixture.componentInstance;
-    router = TestBed.inject(Router);
-    navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
-
     fixture.detectChanges();
   });
 
@@ -45,55 +33,14 @@ describe('AuthPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call loginWithGithub on login', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(of({}));
+  it('should call loginWithGithub on login', async () => {
     component.login();
-
+    await new Promise(resolve => setTimeout(resolve, 0));
     expect(authServiceMock.loginWithGithub).toHaveBeenCalled();
   });
 
-  it('should set user on success', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(of(MOCK_USER));
+  it('should set loading to true when login is called', () => {
     component.login();
-
-    expect(authServiceMock.setUser).toHaveBeenCalledWith(MOCK_USER);
-    expect(component.loading()).toBe(false);
-  });
-
-  it('should navigate to /profile on success', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(of(MOCK_USER));
-    component.login();
-    expect(navigateSpy).toHaveBeenCalledWith(['/profile']);
-  });
-
-  it('should not call loginWithGithub if already loading', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(of(MOCK_USER));
-    component.loading.set(true);
-    component.login();
-
-    expect(authServiceMock.loginWithGithub).not.toHaveBeenCalled();
-    expect(authServiceMock.setUser).not.toHaveBeenCalled();
-  });
-
-  it('should set error on failure', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(
-      throwError(() => new Error('fail'))
-    );
-    component.login();
-
-    expect(component.error()).toBe(true);
-    expect(component.loading()).toBe(false);
-  });
-
-  it('should reset error on retry', () => {
-    authServiceMock.loginWithGithub.mockReturnValue(
-      throwError(() => new Error('fail'))
-    );
-    component.login();
-
-    authServiceMock.loginWithGithub.mockReturnValue(of(MOCK_USER));
-    component.login();
-
-    expect(component.error()).toBe(false);
+    expect(component.loading()).toBe(true);
   });
 });

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.spec.ts
@@ -33,9 +33,9 @@ describe('AuthPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call loginWithGithub on login', async () => {
+  it('should call loginWithGithub on login', () => {
     component.login();
-    await new Promise(resolve => setTimeout(resolve, 0));
+
     expect(authServiceMock.loginWithGithub).toHaveBeenCalled();
   });
 

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
@@ -16,9 +16,6 @@ export class AuthPageComponent {
     if (this.loading()) return;
     
     this.loading.set(true);
-
-    setTimeout(() => {
-      this.authService.loginWithGithub();
-    }, 0);
+    this.authService.loginWithGithub();
   }
 }

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
@@ -14,7 +14,7 @@ export class AuthPageComponent {
 
   login(): void {
     if (this.loading()) return;
-    
+
     this.loading.set(true);
     this.authService.loginWithGithub();
   }

--- a/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
+++ b/frontend/src/app/features/auth/pages/auth-page/auth-page.ts
@@ -1,5 +1,4 @@
 import { Component, inject, signal } from '@angular/core';
-import { Router } from '@angular/router';
 import { AuthService } from '../../data-access/auth-service';
 
 @Component({
@@ -11,27 +10,15 @@ import { AuthService } from '../../data-access/auth-service';
 })
 export class AuthPageComponent {
   private readonly authService = inject(AuthService);
-  private readonly router = inject(Router)
-
   loading = signal(false);
-  error = signal(false);
 
   login(): void {
     if (this.loading()) return;
-
+    
     this.loading.set(true);
-    this.error.set(false);
 
-    this.authService.loginWithGithub().subscribe({
-      next: (user) => {
-        this.authService.setUser(user);
-        this.loading.set(false);
-        this.router.navigate(['/profile']);
-      }, 
-      error: () => {
-        this.error.set(true);
-        this.loading.set(false);
-      },
-    });
+    setTimeout(() => {
+      this.authService.loginWithGithub();
+    }, 0);
   }
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.html
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.html
@@ -1,8 +1,10 @@
-@if (user()) {
+@if (error()) {
+    <p class="profile__error">Authentication failed. Please try again.</p>
+} @else if (user()) {
     <div class="profile__container">
         <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image"/>
         <h2 class="profile__text">{{ user()?.username }}</h2>
     </div>
 } @else {
-    <p class="profile__empty">No user logged in</p>
+    <p class="profile__empty">No user logged in.</p>
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.html
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.html
@@ -4,9 +4,9 @@
     <p class="profile__error">Authentication failed. Please try again.</p>
 } @else if (user()) {
     <div class="profile__container">
-        <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image" />
+        <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image"/>
         <h2 class="profile__text">{{ user()?.username }}</h2>
     </div>
 } @else {
-    <p class="profile__empty">No user logged in.</p>
+    <p class="profile__empty">No user logged in</p>
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.html
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.html
@@ -1,10 +1,12 @@
-@if (error()) {
-    <p class="profile__error">Authentication failed. Please try again.</p>
+@if (loading()) {
+  <p>Loading...</p>
+} @else if (error()) {
+  <p class="profile__error">Authentication failed. Please try again.</p>
 } @else if (user()) {
-    <div class="profile__container">
-        <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image"/>
-        <h2 class="profile__text">{{ user()?.username }}</h2>
-    </div>
+  <div class="profile__container">
+    <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image"/>
+    <h2 class="profile__text">{{ user()?.username }}</h2>
+  </div>
 } @else {
-    <p class="profile__empty">No user logged in.</p>
+  <p class="profile__empty">No user logged in.</p>
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.html
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.html
@@ -1,12 +1,12 @@
 @if (loading()) {
-  <p>Loading...</p>
+    <p>Loading...</p>
 } @else if (error()) {
-  <p class="profile__error">Authentication failed. Please try again.</p>
+    <p class="profile__error">Authentication failed. Please try again.</p>
 } @else if (user()) {
-  <div class="profile__container">
-    <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image"/>
-    <h2 class="profile__text">{{ user()?.username }}</h2>
-  </div>
+    <div class="profile__container">
+        <img [src]="user()?.avatarUrl" alt="avatar" class="profile__image" />
+        <h2 class="profile__text">{{ user()?.username }}</h2>
+    </div>
 } @else {
-  <p class="profile__empty">No user logged in.</p>
+    <p class="profile__empty">No user logged in.</p>
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.spec.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfilePageComponent } from './profile-page';
 import { AuthService } from '../../../auth/data-access/auth-service';
 import { AuthUser } from '../../../auth/models/auth-user.model';
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
 
 const MOCK_USER: AuthUser = {
   username: 'MockUser',
@@ -11,36 +13,74 @@ const MOCK_USER: AuthUser = {
 describe('ProfilePage', () => {
   let component: ProfilePageComponent;
   let fixture: ComponentFixture<ProfilePageComponent>;
-  let authService: AuthService;
+
+  const authServiceMock = {
+    user: vi.fn().mockReturnValue(null),
+    fetchUser: vi.fn(),
+    setUser: vi.fn(),
+  };
 
   beforeEach(async () => {
+    authServiceMock.fetchUser.mockReset();
+    authServiceMock.setUser.mockReset();
+    authServiceMock.user.mockReturnValue(null);
+
     await TestBed.configureTestingModule({
       imports: [ProfilePageComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authServiceMock,
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProfilePageComponent);
     component = fixture.componentInstance;
-    authService = TestBed.inject(AuthService);
-    await fixture.whenStable();
   });
 
   it('should create', () => {
+    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
+    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it('should show fallback message when no user is logged in', () => {
-    const empty = fixture.nativeElement.querySelector('p');
-    expect(empty.textContent).toContain('No user logged in');
+    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
+    fixture.detectChanges();
+
+    authServiceMock.user.mockReturnValue(null);
+    fixture.detectChanges();
+
+    const p = fixture.nativeElement.querySelector('p.profile__empty');
+    expect(p.textContent).toContain('No user logged in');
   });
 
   it('should display avatar and username when user is present', () => {
-    authService.setUser(MOCK_USER);
+    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
+    authServiceMock.user.mockReturnValue(MOCK_USER);
     fixture.detectChanges();
 
-    const avatar = fixture.nativeElement.querySelector('img');
-    const username = fixture.nativeElement.querySelector('h2');
+    const img = fixture.nativeElement.querySelector('img');
+    const h2 = fixture.nativeElement.querySelector('h2');
 
-    expect(avatar.src).toContain(MOCK_USER.avatarUrl);
-    expect(username.textContent).toContain(MOCK_USER.username);
+    expect(img.src).toContain(MOCK_USER.avatarUrl);
+    expect(h2.textContent).toContain(MOCK_USER.username);
+  });
+
+  it('should set error signal when fetchUser fails', () => {
+    authServiceMock.fetchUser.mockReturnValue(
+      throwError(() => new Error('fail'))
+    );
+    fixture.detectChanges();
+
+    expect(component.error()).toBe(true);
+  });
+
+  it('should call setUser with fetched user on success', () => {
+    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
+    fixture.detectChanges();
+
+    expect(authServiceMock.setUser).toHaveBeenCalledWith(MOCK_USER);
   });
 });

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.spec.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.spec.ts
@@ -2,28 +2,32 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfilePageComponent } from './profile-page';
 import { AuthService } from '../../../auth/data-access/auth-service';
 import { AuthUser } from '../../../auth/models/auth-user.model';
+import { signal } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 
 const MOCK_USER: AuthUser = {
   username: 'MockUser',
   avatarUrl: 'https://github.com/MockUser.png',
+  token: 'token-808',
 };
 
 describe('ProfilePage', () => {
   let component: ProfilePageComponent;
   let fixture: ComponentFixture<ProfilePageComponent>;
 
+  const userSignal = signal<AuthUser | null>(null);
+
   const authServiceMock = {
-    user: vi.fn().mockReturnValue(null),
+    user: userSignal,
     fetchUser: vi.fn(),
-    setUser: vi.fn(),
+    setUser: vi.fn((user: AuthUser) => userSignal.set(user)),
   };
 
   beforeEach(async () => {
     authServiceMock.fetchUser.mockReset();
     authServiceMock.setUser.mockReset();
-    authServiceMock.user.mockReturnValue(null);
+    userSignal.set(null);
 
     await TestBed.configureTestingModule({
       imports: [ProfilePageComponent],
@@ -42,45 +46,23 @@ describe('ProfilePage', () => {
   it('should create', () => {
     authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
     fixture.detectChanges();
+
     expect(component).toBeTruthy();
   });
 
-  it('should show fallback message when no user is logged in', () => {
+  it('should call setUser when fetchUser succeeds', () => {
     authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
     fixture.detectChanges();
 
-    authServiceMock.user.mockReturnValue(null);
-    fixture.detectChanges();
-
-    const p = fixture.nativeElement.querySelector('p.profile__empty');
-    expect(p.textContent).toContain('No user logged in');
+    expect(authServiceMock.setUser).toHaveBeenCalledWith(MOCK_USER);
   });
 
-  it('should display avatar and username when user is present', () => {
-    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
-    authServiceMock.user.mockReturnValue(MOCK_USER);
-    fixture.detectChanges();
-
-    const img = fixture.nativeElement.querySelector('img');
-    const h2 = fixture.nativeElement.querySelector('h2');
-
-    expect(img.src).toContain(MOCK_USER.avatarUrl);
-    expect(h2.textContent).toContain(MOCK_USER.username);
-  });
-
-  it('should set error signal when fetchUser fails', () => {
+  it('should set error when fetchUser fails', () => {
     authServiceMock.fetchUser.mockReturnValue(
       throwError(() => new Error('fail'))
     );
     fixture.detectChanges();
 
     expect(component.error()).toBe(true);
-  });
-
-  it('should call setUser with fetched user on success', () => {
-    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
-    fixture.detectChanges();
-
-    expect(authServiceMock.setUser).toHaveBeenCalledWith(MOCK_USER);
   });
 });

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
@@ -9,14 +9,22 @@ import { AuthService } from '../../../auth/data-access/auth-service';
 })
 export class ProfilePageComponent implements OnInit {
   private readonly authService = inject(AuthService);
-  
+
   public user = this.authService.user;
-  error = signal(false);
+
+  public loading = signal(true);
+  public error = signal(false);
 
   ngOnInit(): void {
     this.authService.fetchUser().subscribe({
-      next: (user) => this.authService.setUser(user),
-      error: () => this.error.set(true),
+      next: (user) => {
+        this.authService.setUser(user);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set(true);
+        this.loading.set(false);
+      },
     });
   }
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
@@ -3,7 +3,7 @@ import { AuthService } from '../../../auth/data-access/auth-service';
 
 @Component({
   selector: 'app-profile-page',
-  imports: [],
+  standalone: true,
   templateUrl: './profile-page.html',
   styleUrl: './profile-page.css',
 })
@@ -16,6 +16,13 @@ export class ProfilePageComponent implements OnInit {
   public error = signal(false);
 
   ngOnInit(): void {
+    const user = this.user();
+
+    if (user) {
+      this.loading.set(false);
+      return;
+    }
+
     this.authService.fetchUser().subscribe({
       next: (user) => {
         this.authService.setUser(user);

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { AuthService } from '../../../auth/data-access/auth-service';
 
 @Component({
@@ -7,7 +7,16 @@ import { AuthService } from '../../../auth/data-access/auth-service';
   templateUrl: './profile-page.html',
   styleUrl: './profile-page.css',
 })
-export class ProfilePageComponent {
+export class ProfilePageComponent implements OnInit {
   private readonly authService = inject(AuthService);
-  public readonly user = this.authService.user;
+  
+  public user = this.authService.user;
+  error = signal(false);
+
+  ngOnInit(): void {
+    this.authService.fetchUser().subscribe({
+      next: (user) => this.authService.setUser(user),
+      error: () => this.error.set(true),
+    });
+  }
 }

--- a/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
+++ b/frontend/src/app/features/profile/pages/profile-page/profile-page.ts
@@ -4,6 +4,7 @@ import { AuthService } from '../../../auth/data-access/auth-service';
 @Component({
   selector: 'app-profile-page',
   standalone: true,
+  imports: [],
   templateUrl: './profile-page.html',
   styleUrl: './profile-page.css',
 })


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/350)

## Summary
Refactored the authentication flow from a simple mock-based implementation to a more structured mock flow simulating a GitHub OAuth login

## Changes
- Updated `AuthService` to replace Observable-based login mock with a service-driven mock user flow
- Added `fetchUser()` to simulate backend `/me` endpoint
- Simplified `AuthPageComponent` by delegating login logic to the service
- Added loading and error states in `ProfilePageComponent`
- Introduced `ngOnInit` to hydrate user state on profile load
- Improved profile template with loading/error/empty states handling

## Note
Still uses mocked data, but structured to mimic a real OAuth-based authentication flow for future backend integration