### PR TITLE
feat: implement delete specific challenge from storage #380

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -1,6 +1,8 @@
 package com.itachallenges.challengeservice.catalog.domain.port.out;
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+
 import java.util.List;
 
 public interface ChallengeRepository {
@@ -8,5 +10,5 @@ public interface ChallengeRepository {
     List<Challenge> findAll();
     Challenge update(Challenge challenge);
     Challenge save(Challenge challenge);
-    void delete(String id);
+    void delete(ChallengeId id);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -43,6 +43,7 @@ public class ChallengeController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id) {
+        repository.delete(ChallengeId.of(id));
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -34,8 +34,8 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
     }
 
     @Override
-    public void delete(String id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    public void delete(ChallengeId id) {
+        storage.remove(id);
     }
 
     @Override

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -50,8 +51,18 @@ class InMemoryChallengeRepositoryTest {
         assertThat(result.getDescription().toString()).isEqualTo("New description");
     }
    
+
+
     @Test
-    void delete_shouldThrowUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> repository.delete("any-id"));
+    void should_delete_existing_challenge() {
+        Challenge challenge = Challenge.create("To be deleted", "Description");
+
+        ChallengeId id = challenge.getId();
+        repository.save(challenge);
+        assertThat(repository.findAll()).hasSize(1);
+
+        repository.delete(id);
+
+        assertThat(repository.findAll()).isEmpty();
     }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -66,6 +66,7 @@ class InMemoryChallengeRepositoryTest {
         repository.delete(id);
 
         assertThat(repository.findAll()).isEmpty();
+    }
 
     @Test
     void save_should_store_challenge() {

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -8,6 +8,8 @@ import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
 import org.junit.jupiter.api.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,11 +62,15 @@ class ChallengeControllerTest {
     }
 
 
-    @Test
-    void should_return_204_when_delete_challenge_by_id() throws Exception {
-        mockMvc.perform(delete("/api/challenge/{id}",  "dcacb291-ea40-4924-8430-6d4ef63908f2"))
+    @Test  void should_return_204_when_delete_challenge_by_id() throws Exception {
+        String challengeIdStr = UUID.randomUUID().toString();
+
+        mockMvc.perform(delete("/api/challenge/{id}", challengeIdStr))
                 .andExpect(status().isNoContent());
+
+        verify(repository).delete(any(ChallengeId.class));
     }
+
 
     @Test
     void should_update_challenge_and_return_200() throws Exception {
@@ -82,7 +88,7 @@ class ChallengeControllerTest {
                 "Updated description"
         );
 
-        when(repository.update(org.mockito.ArgumentMatchers.any(Challenge.class)))
+        when(repository.update(any(Challenge.class)))
                 .thenReturn(updatedChallenge);
 
         mockMvc.perform(put("/api/challenge/" + id)


### PR DESCRIPTION
###  Summary

This PR implements the functionality to delete a specific challenge by its unique ID. The changes follow the project's hexagonal architecture, covering the entire flow from the Inbound Adapter (Controller) to the Outbound Port (Repository Port) and the Outbound Persistence Adapter (InMemory Repository).

###  Related Issue

Closes [CRUD] [BE] [Delete] Remove the specific challenge from storage #380


###  Detailed Changes

**1. Infrastructure Layer - Inbound Adapter**

ChallengeController:

Added DELETE /api/challenge/{id} endpoint.

Implemented explicit conversion from path variable String to the Domain Value Object ChallengeId.

Returns 204 No Content upon successful deletion.

**2. Domain Layer - Port**

ChallengeRepository:

Defined the void delete(ChallengeId id) method in the interface to ensure the outbound contract supports deletion.

**3. Infrastructure Layer - Outbound Adapter**

InMemoryChallengeRepository:

Implemented the delete logic using ConcurrentHashMap.remove().

Ensured the operation is idempotent (deleting a non-existent ID does not throw an exception).

**4. Tests & Cleanup**

Unit Tests (InMemoryChallengeRepositoryTest):

Added test cases to verify successful data removal.

Cleanup: Removed obsolete test assertions that previously expected UnsupportedOperationException.

Integration Tests (ChallengeControllerTest):

Used MockMvc to simulate delete requests and verify that the Controller correctly interacts with the Repository port.

###  Verification

Automated Tests: Ran mvn test. All relevant test cases are passing (all green).

Manual Verification (Postman):

Executed POST to create a challenge and retrieved the UUID.

Executed DELETE /api/challenge/{uuid} and received 204 No Content.

### Screenshots

Status Code Verified: 204 No Content

Repository Logic Verified: Confirmed memory storage count decreases accordingly.

<img width="2445" height="1291" alt="repository test" src="https://github.com/user-attachments/assets/82766247-09da-473a-a2b1-f49d8164a314" />

<img width="2417" height="1261" alt="controller test" src="https://github.com/user-attachments/assets/a9bbbc7a-7224-4e74-9d69-3494dd68afc1" />

<img width="1606" height="1010" alt="post man " src="https://github.com/user-attachments/assets/89898c07-ef07-4773-9f6f-3ee2ea303c34" />



