### PR TITLE
feat(auth): replace mock auth with GitHub OAuth and backend user fetch

### DIFF
--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
+import { vi } from 'vitest';
 
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
@@ -12,10 +15,22 @@ const MOCK_USER: AuthUser = {
 
 describe('AuthService', () => {
   let service: AuthService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
     service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
@@ -32,22 +47,36 @@ describe('AuthService', () => {
     expect(service.getUser()).toEqual(MOCK_USER);
   });
 
-  it('should set mock user and redirect to profile when loginWithGithub is called', () => {
-    const originalLocation = globalThis.location;
+  it('should redirect to github when loginWithGithub is called', () => {
     const locationMock = { href: '' };
-
     vi.stubGlobal('location', locationMock);
 
     service.loginWithGithub();
 
-    expect(service.user()).toEqual(MOCK_USER);
-    expect(locationMock.href).toBe('/profile');
+    expect(locationMock.href).toBe('/api/account/oauth2/authorization/github');
 
-    vi.stubGlobal('location', originalLocation);
+    vi.unstubAllGlobals();
   });
 
-  it('should fetch mock user', async () => {
-    const result = await firstValueFrom(service.fetchUser());
+  it('should not modify user signal when loginWithGithub is called', () => {
+    const locationMock = { href: '' };
+    vi.stubGlobal('location', locationMock);
+
+    service.loginWithGithub();
+
+    expect(service.user()).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should fetch user from API', async () => {
+    const promise = firstValueFrom(service.fetchUser());
+
+    const req = httpMock.expectOne('/api/account/auth/me');
+    expect(req.request.method).toBe('GET');
+    req.flush(MOCK_USER);
+
+    const result = await promise;
     expect(result).toEqual(MOCK_USER);
   });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -50,7 +50,6 @@ describe('AuthService', () => {
   it('should redirect to github when loginWithGithub is called', () => {
     const locationMock = { href: '' };
     vi.stubGlobal('location', locationMock);
-
     service.loginWithGithub();
 
     expect(locationMock.href).toBe('/api/account/oauth2/authorization/github');
@@ -61,7 +60,6 @@ describe('AuthService', () => {
   it('should not modify user signal when loginWithGithub is called', () => {
     const locationMock = { href: '' };
     vi.stubGlobal('location', locationMock);
-
     service.loginWithGithub();
 
     expect(service.user()).toBeNull();

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
 
@@ -9,15 +9,17 @@ import { AuthUser } from '../models/auth-user.model';
 export class AuthService {
   private readonly http = inject(HttpClient);
 
+  private readonly githubLoginUrl = '/api/account/oauth2/authorization/github';
+  private readonly currentUserUrl = '/api/account/auth/me';
+
   user = signal<AuthUser | null>(null);
 
-
   loginWithGithub(): void {
-    globalThis.location.href = '/api/account/oauth2/authorization/github';
+    globalThis.location.href = this.githubLoginUrl;
   }
 
   fetchUser(): Observable<AuthUser> {
-    return this.http.get<AuthUser>('/api/account/auth/me');
+    return this.http.get<AuthUser>(this.currentUserUrl);
   }
 
   setUser(user: AuthUser): void {

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -11,20 +11,13 @@ export class AuthService {
 
   user = signal<AuthUser | null>(null);
 
-  private readonly mockUser: AuthUser = {
-    username: 'mockUser',
-    avatarUrl: 'https://github.com/MockUser.png',
-    token: 'token-808'
-  };
 
   loginWithGithub(): void {
-    this.setUser(this.mockUser);
-
-    globalThis.location.href = '/profile';
+    globalThis.location.href = '/api/account/oauth2/authorization/github';
   }
 
   fetchUser(): Observable<AuthUser> {
-    return of(this.mockUser);
+    return this.http.get<AuthUser>('/api/account/auth/me');
   }
 
   setUser(user: AuthUser): void {


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/436)

## Summary
Replaced the mock-based authentication with a real GitHub OAuth flow and backend user retrieval

## Changes
- Updated `AuthService` to remove mock user and mock login logic  
- Implemented GitHub OAuth redirect via `/api/account/oauth2/authorization/github`  
- Replaced `fetchUser()` mock with real HTTP call to `/api/account/auth/me`  
- Connected authentication flow to backend endpoints  

## Note
Authentication now depends on the backend OAuth flow and `/me` endpoint instead of local mock data