### PR TITLE
fix(challenge): restore delete test #453

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -116,4 +116,28 @@ describe('ChallengeApiService', () => {
       req.flush('Error interno', { status: 500, statusText: 'Internal Server Error' });
     });
   });
+
+  describe('delete', () => {
+    it('should call DELETE with the correct URL', () => {
+      const mockId = '123';
+
+      service.delete(mockId).subscribe();
+
+      const req = httpTestingController.expectOne(`${apiUrl}/${mockId}`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    it('should return undefined if HTTP error happens', () => {
+      const mockId = '456';
+      let responseResult: any = 'initial_value';
+
+      service.delete(mockId).subscribe(result => responseResult = result);
+
+      const req = httpTestingController.expectOne(`${apiUrl}/${mockId}`);
+      req.flush('Not Found', { status: 404, statusText: 'Not Found' });
+
+      expect(responseResult).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
[Task issue](https://github.com/IT-Academy-BCN/ita-challenges/issues/453)

### Description
Restore missing delete unit tests for the service ChallengeApiService, it was deleted by mistake during a merge conflict resolution in the create branch.

### Goal

- Restore delete unit tests.