### PR TITLE
chore(contributors): add Jordi Casas to contributors.md

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,3 +1,4 @@
 # List of developers contributors
 
 - Rafael di Candia
+- Jordi Casas - https://github.com/JordiCasas87


### PR DESCRIPTION
## Summary
- add Jordi Casas to `contributors.md`
- include GitHub profile link
