### PR TITLE
feat: add UserRequest DTO

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Role.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Role.java
@@ -1,7 +1,7 @@
 package com.ita.challenges.account.domain.model;
 
 public enum Role {
-    ADMIN,
+    MENTOR,
     STUDENT,
     GUEST
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Role.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Role.java
@@ -1,0 +1,7 @@
+package com.ita.challenges.account.domain.model;
+
+public enum Role {
+    ADMIN,
+    STUDENT,
+    GUEST
+}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/UserRequest.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/UserRequest.java
@@ -1,0 +1,8 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
+
+import com.ita.challenges.account.domain.model.Role;
+
+public record UserRequest(
+        String username,
+        Role role
+) {}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserSerializationTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserSerializationTest.java
@@ -1,0 +1,44 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ita.challenges.account.domain.model.Role;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserSerializationTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    void should_deserialize_valid_request_for_each_role(Role role) throws Exception {
+        String json = """
+                {
+                  "username": "john",
+                  "role": "%s"
+                }
+                """.formatted(role.name());
+
+        UserRequest result = mapper.readValue(json, UserRequest.class);
+
+        assertThat(result.username()).isEqualTo("john");
+        assertThat(result.role()).isEqualTo(role);
+    }
+
+    @Test
+    void should_fail_when_role_is_unknown() {
+        String json = """
+                {
+                  "username": "john",
+                  "role": "SUPERUSER"
+                }
+                """;
+
+        assertThatThrownBy(() -> mapper.readValue(json, UserRequest.class))
+                .isInstanceOf(Exception.class);
+    }
+}


### PR DESCRIPTION
## What
Adds `UserRequest` DTO and `Role` enum as part of the API contracts scaffolding.

## Changes
- `UserRequest` — record with `username` (String) and `role` (Role) fields
- `Role` — enum with `ADMIN`, `STUDENT`, `GUEST`
- `UserRequestSerializationTest` — covers JSON → DTO deserialization for all enum values and rejects unknown roles

## Pending
- `Role.java` is temporary here — belongs to PR 0.1. Remove once merged and rebase.
- Validations (`@NotBlank`, `@NotNull`) not included — deferred to a later PR.