### PR TITLE
feat: add create user endpoint placeholder

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -2,12 +2,14 @@ package com.ita.challenges.account.infrastructure.adapter.web.in;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/account/users")
+@CrossOrigin(origins = "http://localhost:4200")
 public class UserController {
 
     @PostMapping

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,0 +1,17 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/account/users")
+public class UserController {
+
+    @PostMapping
+    public ResponseEntity<Void> create() {
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -16,7 +18,10 @@ class UserControllerTest {
 
     @Test
     void create_shouldReturn200() throws Exception {
-        mockMvc.perform(post("/api/account/users"))
+        mockMvc.perform(post("/api/account/users")
+                        .with(oauth2Login())
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -1,4 +1,22 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
-public class UserControllerTest {
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void create_shouldReturn200() throws Exception {
+        mockMvc.perform(post("/api/account/users"))
+                .andExpect(status().isOk());
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -1,0 +1,4 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in;
+
+public class UserControllerTest {
+}


### PR DESCRIPTION
## Description
Defined the `create` endpoint to handle user creation.

## Changes
- `UserController`: added empty `create` method returning 200 OK.
- `UserControllerTest`: added test for create endpoint.

## Implementation details
The endpoint currently acts as a placeholder. The logic will be handled in a subsequent task.