### PR TITLE
feat(create-button): add base "Create Challenge" button component

### DIFF
--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
@@ -1,0 +1,3 @@
+<button routerLink="/challenges/create">
+  Create Challenge
+</button>

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
@@ -1,3 +1,3 @@
-<button routerLink="/challenges/create">
+<button>
   Create Challenge
 </button>

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CreateButtonComponent } from './create-button';
+import { provideRouter } from '@angular/router';
+import { By } from '@angular/platform-browser';
+
+describe('CreateButtonComponent', () => {
+  let component: CreateButtonComponent;
+  let fixture: ComponentFixture<CreateButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreateButtonComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render a button', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button).toBeTruthy();
+  });
+
+  it('should render button with text "Create Challenge"', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.textContent.trim()).toBe('Create Challenge');
+  });
+
+  it('should have routerLink directive pointing to /challenges/create', () => {
+    const button = fixture.debugElement.query(By.css('button'));
+    
+    expect(button).toBeTruthy();
+    expect(button.attributes['routerLink']).toBe('/challenges/create');
+  });
+});

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
@@ -31,11 +31,4 @@ describe('CreateButtonComponent', () => {
     const button = fixture.nativeElement.querySelector('button');
     expect(button.textContent.trim()).toBe('Create Challenge');
   });
-
-  it('should have routerLink directive pointing to /challenges/create', () => {
-    const button = fixture.debugElement.query(By.css('button'));
-    
-    expect(button).toBeTruthy();
-    expect(button.attributes['routerLink']).toBe('/challenges/create');
-  });
 });

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateButtonComponent } from './create-button';
 import { provideRouter } from '@angular/router';
-import { By } from '@angular/platform-browser';
 
 describe('CreateButtonComponent', () => {
   let component: CreateButtonComponent;

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
@@ -3,9 +3,8 @@ import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-create-button',
-  imports: [
-    RouterLink
-  ],
+  standalone: true,
+  imports: [RouterLink],
   templateUrl: './create-button.html',
   styleUrl: './create-button.css',
 })

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
@@ -1,10 +1,9 @@
 import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-create-button',
   standalone: true,
-  imports: [RouterLink],
+  imports: [],
   templateUrl: './create-button.html',
   styleUrl: './create-button.css',
 })

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-create-button',
+  imports: [
+    RouterLink
+  ],
+  templateUrl: './create-button.html',
+  styleUrl: './create-button.css',
+})
+export class CreateButtonComponent {
+
+}

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -1,5 +1,7 @@
 <h1>Llistat de Reptes</h1>
 
+<app-create-button></app-create-button>
+
 @if (challenges().length > 0) {
 <ul>
     @for (challenge of challenges(); track $index) {

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 
 import { ChallengesListPage } from './challenges-list-page';
 import { ChallengeService } from '../../services/challenge.service';
+import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
 import { CHALLENGES_MOCK } from '../../models/challenges.mock';
 
 describe('ChallengesListPage', () => {
@@ -11,13 +14,12 @@ describe('ChallengesListPage', () => {
   let mockChallengeService: any;
 
   beforeEach(async () => {
-    mockChallengeService = {
-      loadAll: () => of(CHALLENGES_MOCK)
-    };
+    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK))};
 
     await TestBed.configureTestingModule({
       imports: [ChallengesListPage],
       providers: [
+        provideRouter([]),
         { provide: ChallengeService, useValue: mockChallengeService }
       ]
     })
@@ -33,13 +35,20 @@ describe('ChallengesListPage', () => {
   });
 
   it('should load challenges on initialization', () => {
+    expect(mockChallengeService.loadAll).toHaveBeenCalled();
     expect(component.challenges()).toEqual(CHALLENGES_MOCK);
   });
 
   it('should render challenges in the template', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const listItems = compiled.querySelectorAll('li');
+
     expect(listItems.length).toBe(CHALLENGES_MOCK.length);
     expect(listItems[0].textContent).toContain(CHALLENGES_MOCK[0].title);
+  });
+
+  it('should render create button component', () => {
+    const button = fixture.debugElement.query(By.directive(CreateButtonComponent));
+    expect(button).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,7 +1,7 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
-import { CreateButtonComponent } from "../../components/buttons/create-button/create-button";
+import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
 
 @Component({
   selector: 'app-challenges-list-page',

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,10 +1,11 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
+import { CreateButtonComponent } from "../../components/buttons/create-button/create-button";
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [],
+  imports: [CreateButtonComponent],
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
 })


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/541)

## Summary
Created a reusable `CreateButtonComponent`.

## What's included
- Added `CreateButtonComponent` in `challenges/components/buttons/create-button/`
- Integrated `<app-create-button>` into `ChallengesListPage`
- Added unit tests for the button component (render, text)

## Notes
Role-based visibility (show/hide button based on Mentor/Student role) is out of scope for this task and will be handled in a separate issue once the role selector is implemented.