### PR TITLE
feat(account): add ticket controller and minimal test

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -1,0 +1,10 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/account/tickets")
+public class TicketController {
+
+}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -6,7 +6,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @WebMvcTest(TicketController.class)
 class TicketControllerTest {
@@ -16,7 +17,8 @@ class TicketControllerTest {
 
     @Test
     @WithMockUser
-    void contextLoads() throws Exception {
-        assertNotNull(mockMvc);
+    void shouldLoadTicketEndpoint() throws Exception {
+        mockMvc.perform(get("/api/account/tickets"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -1,0 +1,22 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@WebMvcTest(TicketController.class)
+class TicketControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    void contextLoads() throws Exception {
+        assertNotNull(mockMvc);
+    }
+}


### PR DESCRIPTION
Closes #473

### Description

1. add the minimal Ticket entry point in account-service
2. add TicketController to handle incoming requests at /api/account/tickets
3. add a WebMvc test to verify the controller's registration within the Spring context


### Scope note
The supporting scope of this PR is limited to the initial web adapter and its corresponding verification test.

### Supporting changes:
minimal TicketController and TicketControllerTest in account-service

### Supporting scope:

2 files

30 lines