### PR TITLE
feat(role): add global role service (#542)

### DIFF
--- a/frontend/src/app/core/models/role.model.ts
+++ b/frontend/src/app/core/models/role.model.ts
@@ -1,0 +1,1 @@
+export type Role = 'mentor' | 'student';

--- a/frontend/src/app/core/models/role.model.ts
+++ b/frontend/src/app/core/models/role.model.ts
@@ -1,1 +1,1 @@
-export type Role = 'mentor' | 'student';
+export type Role = 'mentor' | 'student' | 'guest';

--- a/frontend/src/app/core/services/role.service.spec.ts
+++ b/frontend/src/app/core/services/role.service.spec.ts
@@ -14,8 +14,8 @@ describe('RoleService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should have default role as student', () => {
-    expect(service.role()).toBe('student');
+  it('should have default role as guest', () => {
+    expect(service.role()).toBe('guest');
   });
 
   it('should update role when setRole is called', () => {
@@ -34,12 +34,28 @@ describe('RoleService', () => {
     expect(service.isMentor()).toBe(true);
   });
 
-  it('should reflect isMentor back to false when role changes to student', () => {
+  it('should reflect isMentor back to false when role changes to guest', () => {
     service.setRole('mentor');
-    service.setRole('student');
+    service.setRole('guest');
 
     expect(service.isMentor()).toBeFalsy();
-    expect(service.role()).toBe('student');
+    expect(service.role()).toBe('guest');
+  });
+
+  it('should reflect isStudent correctly', () => {
+    expect(service.isStudent()).toBeFalsy();
+
+    service.setRole('student');
+
+    expect(service.isStudent()).toBe(true);
+  });
+
+  it('should reflect isGuest correctly', () => {
+    expect(service.isGuest()).toBe(true);
+
+    service.setRole('mentor');
+
+    expect(service.isGuest()).toBe(false);
   });
 
   it('should keep role reactive across multiple updates', () => {
@@ -53,7 +69,15 @@ describe('RoleService', () => {
     service.setRole('student');
     values.push(service.role());
 
-    expect(values).toEqual(['student', 'mentor', 'student']);
+    service.setRole('guest');
+    values.push(service.role());
+
+    expect(values).toEqual([
+      'guest',
+      'mentor',
+      'student',
+      'guest',
+    ]);
   });
 
   it('should keep computed isMentor reactive', () => {
@@ -64,7 +88,7 @@ describe('RoleService', () => {
     service.setRole('mentor');
     states.push(service.isMentor());
 
-    service.setRole('student');
+    service.setRole('guest');
     states.push(service.isMentor());
 
     expect(states).toEqual([false, true, false]);

--- a/frontend/src/app/core/services/role.service.spec.ts
+++ b/frontend/src/app/core/services/role.service.spec.ts
@@ -20,7 +20,6 @@ describe('RoleService', () => {
 
   it('should update role when setRole is called', () => {
     service.setRole('mentor');
-
     expect(service.role()).toBe('mentor');
   });
 
@@ -30,7 +29,6 @@ describe('RoleService', () => {
 
   it('should reflect isMentor as true when role is mentor', () => {
     service.setRole('mentor');
-
     expect(service.isMentor()).toBe(true);
   });
 
@@ -44,17 +42,13 @@ describe('RoleService', () => {
 
   it('should reflect isStudent correctly', () => {
     expect(service.isStudent()).toBeFalsy();
-
     service.setRole('student');
-
     expect(service.isStudent()).toBe(true);
   });
 
   it('should reflect isGuest correctly', () => {
     expect(service.isGuest()).toBe(true);
-
     service.setRole('mentor');
-
     expect(service.isGuest()).toBe(false);
   });
 
@@ -72,11 +66,7 @@ describe('RoleService', () => {
     service.setRole('guest');
     values.push(service.role());
 
-    expect(values).toEqual([
-      'guest',
-      'mentor',
-      'student',
-      'guest',
+    expect(values).toEqual(['guest','mentor','student','guest',
     ]);
   });
 

--- a/frontend/src/app/core/services/role.service.spec.ts
+++ b/frontend/src/app/core/services/role.service.spec.ts
@@ -52,34 +52,4 @@ describe('RoleService', () => {
     expect(service.isGuest()).toBe(false);
   });
 
-  it('should keep role reactive across multiple updates', () => {
-    const values: Role[] = [];
-
-    values.push(service.role());
-
-    service.setRole('mentor');
-    values.push(service.role());
-
-    service.setRole('student');
-    values.push(service.role());
-
-    service.setRole('guest');
-    values.push(service.role());
-
-    expect(values).toEqual(['guest','mentor','student','guest']);
-  });
-
-  it('should keep computed isMentor reactive', () => {
-    const states: boolean[] = [];
-
-    states.push(service.isMentor());
-
-    service.setRole('mentor');
-    states.push(service.isMentor());
-
-    service.setRole('guest');
-    states.push(service.isMentor());
-
-    expect(states).toEqual([false, true, false]);
-  });
 });

--- a/frontend/src/app/core/services/role.service.spec.ts
+++ b/frontend/src/app/core/services/role.service.spec.ts
@@ -66,8 +66,7 @@ describe('RoleService', () => {
     service.setRole('guest');
     values.push(service.role());
 
-    expect(values).toEqual(['guest','mentor','student','guest',
-    ]);
+    expect(values).toEqual(['guest','mentor','student','guest']);
   });
 
   it('should keep computed isMentor reactive', () => {

--- a/frontend/src/app/core/services/role.service.spec.ts
+++ b/frontend/src/app/core/services/role.service.spec.ts
@@ -1,0 +1,72 @@
+import { TestBed } from '@angular/core/testing';
+import { RoleService } from './role.service';
+import { Role } from '../models/role.model';
+
+describe('RoleService', () => {
+  let service: RoleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RoleService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should have default role as student', () => {
+    expect(service.role()).toBe('student');
+  });
+
+  it('should update role when setRole is called', () => {
+    service.setRole('mentor');
+
+    expect(service.role()).toBe('mentor');
+  });
+
+  it('should reflect isMentor as false by default', () => {
+    expect(service.isMentor()).toBeFalsy();
+  });
+
+  it('should reflect isMentor as true when role is mentor', () => {
+    service.setRole('mentor');
+
+    expect(service.isMentor()).toBe(true);
+  });
+
+  it('should reflect isMentor back to false when role changes to student', () => {
+    service.setRole('mentor');
+    service.setRole('student');
+
+    expect(service.isMentor()).toBeFalsy();
+    expect(service.role()).toBe('student');
+  });
+
+  it('should keep role reactive across multiple updates', () => {
+    const values: Role[] = [];
+
+    values.push(service.role());
+
+    service.setRole('mentor');
+    values.push(service.role());
+
+    service.setRole('student');
+    values.push(service.role());
+
+    expect(values).toEqual(['student', 'mentor', 'student']);
+  });
+
+  it('should keep computed isMentor reactive', () => {
+    const states: boolean[] = [];
+
+    states.push(service.isMentor());
+
+    service.setRole('mentor');
+    states.push(service.isMentor());
+
+    service.setRole('student');
+    states.push(service.isMentor());
+
+    expect(states).toEqual([false, true, false]);
+  });
+});

--- a/frontend/src/app/core/services/role.service.ts
+++ b/frontend/src/app/core/services/role.service.ts
@@ -1,0 +1,16 @@
+import { computed, Injectable, signal } from '@angular/core';
+import { Role } from '../models/role.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RoleService {
+  private readonly _role = signal<Role>('student');
+
+  role = this._role.asReadonly();
+  isMentor = computed(() => this._role() === 'mentor');
+
+  setRole(role: Role): void {
+    this._role.set(role);
+  }
+}

--- a/frontend/src/app/core/services/role.service.ts
+++ b/frontend/src/app/core/services/role.service.ts
@@ -5,10 +5,13 @@ import { Role } from '../models/role.model';
   providedIn: 'root',
 })
 export class RoleService {
-  private readonly _role = signal<Role>('student');
+  private readonly _role = signal<Role>('guest');
 
   role = this._role.asReadonly();
+
   isMentor = computed(() => this._role() === 'mentor');
+  isStudent = computed(() => this._role() === 'student');
+  isGuest = computed(() => this._role() === 'guest');
 
   setRole(role: Role): void {
     this._role.set(role);


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/542)

## Summary
Created a global `RoleService` to manage application-wide role state (Mentor / Student) using signals. This provides a single source of truth for role-based logic across the app.

## What's included
- Added `Role` type (`mentor | student | guest`) in `core/models`
- Created `RoleService` in `core/services`
- Implemented signal-based state management for role
- Exposed readonly `role` signal for app-wide consumption
- Added `setRole()` method to update the active role
- Added `isMentor`, `isStudent` and `isGuest` computed signal for role-based logic
- Unit tests added for role state updates

## Notes
This task focuses exclusively on state management. No UI components or role-based rendering logic are included in this scope.