### PR TITLE
feat(auth-guard): add async session restoration fallback (#569)

### DIFF
--- a/frontend/src/app/core/guards/auth-guard.ts
+++ b/frontend/src/app/core/guards/auth-guard.ts
@@ -1,5 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
+import { catchError, map, of } from 'rxjs';
 import { AuthService } from '../../features/auth/data-access/auth-service';
 
 export const authGuard: CanActivateFn = () => {
@@ -10,5 +11,11 @@ export const authGuard: CanActivateFn = () => {
 
   return user
     ? true
-    : router.createUrlTree(['/auth']);
+    : auth.fetchUser().pipe(
+        map(user => {
+          auth.setUser(user);
+          return true;
+        }),
+        catchError(() => of(router.createUrlTree(['/auth'])))
+      );
 };


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/569)

## Summary
Updated auth guard to support backend session restoration when no in-memory user is available.

## What's changed
- Replaced pure in-memory check with async fallback using `fetchUser()`
- On missing in-memory user, attempt to restore session from backend
- Store retrieved user in memory using `setUser()`
- Redirect to `/auth` if session restoration fails

## Notes
This change allows authenticated sessions to persist across page refresh while keeping the original fast-path check for in-memory users. 
This is an update to the implementation introduced in PR #448