### PR TITLE
feat(auth): creation of the basic frontend structure for assigning user roles

### DIFF
--- a/frontend/src/app/core/models/role.enum.ts
+++ b/frontend/src/app/core/models/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  MENTOR = 'MENTOR',
+  STUDENT = 'STUDENT',
+  GUEST = 'GUEST'
+}

--- a/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AdminApiService } from './admin-api.service';
+
+describe('AdminApiService', () => {
+  let service: AdminApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AdminApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/admin/data-access/admin-api.service.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Role } from '../../../core/models/role.enum';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminApiService {
+  
+  setUserRole(username: string, role: Role){
+    return
+  }
+
+}

--- a/frontend/src/app/shared/models/iuser.interface.ts
+++ b/frontend/src/app/shared/models/iuser.interface.ts
@@ -1,0 +1,6 @@
+import { Role } from "../../core/models/role.enum";
+
+export interface IUser {
+    username: string,
+    role: Role,
+}


### PR DESCRIPTION
## Goal

Create the minimal structure to manage user roles on the frontend. This structure will help remove dependencies between tasks.

## To Do

- Create the `Role` enum with the values `MENTOR, STUDENT, GUEST`
- Create the `IUser` interface with the fields `username: string` and `role: Role`
- Create the `admin-api.service.ts` service with the `setUserRole(username, role)` function without logic

## Out of Scope

No logic should be implemented, only the basic project structure