### PR TITLE
feat: add validation to ChallengeTitle and ChallengeDescription

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDescription.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDescription.java
@@ -2,6 +2,11 @@ package com.itachallenges.challengeservice.catalog.domain.valueobject;
 
 public record ChallengeDescription(String value) {
 
+    public ChallengeDescription {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Description must not be null, empty or blank");
+        }
+    }
     @Override
     public String toString() {
         return value;

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeTitle.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeTitle.java
@@ -2,6 +2,11 @@ package com.itachallenges.challengeservice.catalog.domain.valueobject;
 
 public record ChallengeTitle(String value) {
 
+    public ChallengeTitle {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Title must not be null, empty or blank.");
+        }
+    }
     @Override
     public String toString() {
         return value;

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDescriptionTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDescriptionTest.java
@@ -1,0 +1,33 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChallengeDescriptionTest {
+
+    @Test
+    void should_create_description_with_valid_value() {
+        ChallengeDescription description = new ChallengeDescription("A valid description");
+
+        assertThat(description.value()).isEqualTo("A valid description");
+    }
+
+    @Test
+    void should_throw_exception_when_description_is_null() {
+        assertThatThrownBy(() -> new ChallengeDescription(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_description_is_empty() {
+        assertThatThrownBy(() -> new ChallengeDescription(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_description_is_blank() {
+        assertThatThrownBy(() -> new ChallengeDescription("   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeTitleTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeTitleTest.java
@@ -1,0 +1,33 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChallengeTitleTest {
+
+    @Test
+    void should_create_title_with_valid_value() {
+        ChallengeTitle title = new ChallengeTitle("Clean Code Challenge");
+
+        assertThat(title.value()).isEqualTo("Clean Code Challenge");
+    }
+
+    @Test
+    void should_throw_exception_when_title_is_null() {
+        assertThatThrownBy(() -> new ChallengeTitle(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_title_is_empty() {
+        assertThatThrownBy(() -> new ChallengeTitle(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_title_is_blank() {
+        assertThatThrownBy(() -> new ChallengeTitle("   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Added minimum backend validation to ChallengeTitle and ChallengeDescription value objects 
to reject null, empty, and blank values using a compact constructor.

Also added unit tests for both valid and invalid values.

Closes #573