### PR TITLE
feat: define answer progress states

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/AnswerStatus.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/AnswerStatus.java
@@ -1,0 +1,9 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+
+public enum AnswerStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    SUBMITTED,
+    APPROVED,
+    FAILED_REVIEW
+}


### PR DESCRIPTION
## Added AnswerStatus enum to define the lifecycle states of an answer:

- NOT_STARTED
- IN_PROGRESS
- SUBMITTED
- APPROVED
- FAILED_REVIEW

No unit tests added as there are no existing tests for the domain layer yet.

Closes #579