### PR TITLE
doc(challenge): review create challenge endpoint contract

### DIFF
--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -54,7 +54,7 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void should_return_201_with_challenge_when_valid_request() throws Exception {
+    void should_create_challenge_with_tittle_and_description_and_return_201() throws Exception {
         Challenge saved = Challenge.create(request.title(), request.description());
         when(repository.save(any(Challenge.class))).thenReturn(saved);
 
@@ -67,7 +67,6 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.description").value("A challenge about writing clean and maintainable code"));
     }
 
-
     @Test  void should_return_204_when_delete_challenge_by_id() throws Exception {
         String challengeIdStr = UUID.randomUUID().toString();
 
@@ -76,7 +75,6 @@ class ChallengeControllerTest {
 
         verify(repository).delete(any(ChallengeId.class));
     }
-
 
     @Test
     void should_update_challenge_and_return_200() throws Exception {

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -54,7 +54,7 @@ class ChallengeControllerTest {
     }
 
     @Test
-    void should_create_challenge_with_tittle_and_description_and_return_201() throws Exception {
+    void should_create_challenge_with_title_and_description_and_return_201() throws Exception {
         Challenge saved = Challenge.create(request.title(), request.description());
         when(repository.save(any(Challenge.class))).thenReturn(saved);
 


### PR DESCRIPTION
## Description

This PR reviews the current create challenge endpoint and clarifies its request and response structure for the MVP flow. It also documents the endpoint location in the repository.

The related controller test was renamed to make the endpoint behavior and expected contract easier to understand.

This PR is mainly informative and serves as a reference and validation point for future challenge creation integration and usage.

## Endpoint

`POST /api/challenge`


## Controller Location

```text
backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
```

## Request DTO

ChallengeRequest

```java
public record ChallengeRequest(
    String title,
    String description
) {}
```


## Expected Request Body

```json
{
  "title": "The Last Merge Conflict",
  "description": "Resolve the contributors.md conflict before the sprint review destroys the team."
}
```


---

## Expected Response

HTTP Status:

```text
201 Created
```

Response body:

```json
{
  "id": "uuid",
  "title": "The Last Merge Conflict",
  "description": "Resolve the contributors.md conflict before the sprint review destroys the team."
}
```

## Backend health check using curl

<img width="950" height="230" alt="Captura de pantalla 2026-05-07 a las 18 13 14" src="https://github.com/user-attachments/assets/edc45295-d1a2-4d93-8651-d7b4d75f1afd" />

## Create challenge endpoint tested with Postman

<img width="848" height="661" alt="Captura de pantalla 2026-05-07 a las 18 16 08" src="https://github.com/user-attachments/assets/d3b05223-6460-40f0-8f56-f7499201cd0d" />
