### PR TITLE
fix: adapt User getters to the new domain to fix tests

### DIFF
--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/UserTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/UserTest.java
@@ -17,8 +17,8 @@ class UserTest {
         User user = new User(userName, userRole);
 
         assertNotNull(user);
-        assertEquals(userName, user.getUserName());
-        assertEquals(userRole, user.getUserRole());
+        assertEquals(userName, user.userName());
+        assertEquals(userRole, user.userRole());
     }
 
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
@@ -31,6 +31,6 @@ class InMemoryUserRepositoryTest {
     void should_overwrite_existing_user() {
         repository.save(new User("john", Role.GUEST));
         repository.save(new User("john", Role.MENTOR));
-        assertThat(repository.storage.get("john").role()).isEqualTo(Role.MENTOR);
+        assertThat(repository.storage.get("john").userRole()).isEqualTo(Role.MENTOR);
     }
 }


### PR DESCRIPTION
This PR fixes User getters inconsistency to make tests pass, please review and merge at your earliest convenience.