### PR TITLE
(Ticketing): define update method in TicketRepository

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
@@ -1,4 +1,7 @@
 package com.ita.challenges.account.domain.port.out;
 
+import com.ita.challenges.account.domain.model.Ticket;
+
 public interface TicketRepository {
+    Ticket updateTicket(Ticket ticket);
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
@@ -1,8 +1,13 @@
 package com.ita.challenges.account.infrastructure.adapter.web.out.persistence;
 
+import com.ita.challenges.account.domain.model.Ticket;
 import com.ita.challenges.account.domain.port.out.TicketRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryTicketRepository implements TicketRepository {
+    @Override
+    public Ticket updateTicket(Ticket ticket) {
+        throw new UnsupportedOperationException("updateTicket not implemented yet");
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -1,0 +1,23 @@
+package com.ita.challenges.account.infrastructure.adapter.web.out.persistence;
+
+import com.ita.challenges.account.domain.model.Ticket;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InMemoryTicketRepositoryTest {
+    private final InMemoryTicketRepository repository = new InMemoryTicketRepository();
+
+    @Test
+    void updateTicket_should_throw_unsupported_operation_exception() {
+
+        Ticket ticket = Ticket.create("user-1", "Update Task", "Description");
+
+        UnsupportedOperationException exception =
+                assertThrows(UnsupportedOperationException.class, () -> {
+                    repository.updateTicket(ticket);
+                });
+
+        assertEquals("updateTicket not implemented yet", exception.getMessage());
+    }
+}


### PR DESCRIPTION
### Summary
add updateTicket(Ticket ticket) to TicketRepository

add a provisional override in InMemoryTicketRepository

add a simple test for the provisional implementation

### Note
This PR only defines the contract required to update a ticket and leaves the real storage logic for the following sub-issue.

closes #481 