### PR TITLE
feat(ticketing): prepare ticket update entry point

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -1,10 +1,19 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/account/tickets")
 public class TicketController {
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TicketResponse> update(
+            @PathVariable String id,
+            @RequestBody TicketRequest ticketRequest) {
+        throw new UnsupportedOperationException("Update endpoint not implemented yet for ID: " + id);
+    }
 
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -1,16 +1,25 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @WebMvcTest(TicketController.class)
 class TicketControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private MockMvc mockMvc;
@@ -20,5 +29,23 @@ class TicketControllerTest {
     void shouldLoadTicketEndpoint() throws Exception {
         mockMvc.perform(get("/api/account/tickets"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    void should_return_error_when_updating_ticket_because_not_implemented() throws Exception {
+
+        String ticketId = "123";
+        TicketRequest request = new TicketRequest("title","description");
+
+        Exception exception = assertThrows(Exception.class, () -> {
+            mockMvc.perform(put("/api/account/tickets/{id}", ticketId)
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+        });
+
+        assertInstanceOf(UnsupportedOperationException.class, exception.getCause());
+        assertEquals("Update endpoint not implemented yet for ID: 123", exception.getCause().getMessage());
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -25,12 +25,6 @@ class TicketControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Test
-    @WithMockUser
-    void shouldLoadTicketEndpoint() throws Exception {
-        mockMvc.perform(get("/api/account/tickets"))
-                .andExpect(status().isNotFound());
-    }
 
     @Test
     @WithMockUser

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -2,6 +2,7 @@ package com.ita.challenges.account.infrastructure.adapter.web.in;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -38,7 +39,7 @@ class TicketControllerTest {
         String ticketId = "123";
         TicketRequest request = new TicketRequest("title","description");
 
-        Exception exception = assertThrows(Exception.class, () -> {
+        ServletException exception = assertThrows(ServletException.class, () -> {
             mockMvc.perform(put("/api/account/tickets/{id}", ticketId)
                     .with(csrf())
                     .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
### Summary

add update method to TicketController with @PutMapping("/{id}")

add TicketControllerTest using MockMvc to verify the provisional exception

### Note
This PR establishes the API contract for ticket updates. It includes security configurations in the test (CSRF & MockUser) to ensure the endpoint is reachable.
closes #482 

<img width="1617" height="1017" alt="屏幕截图 2026-05-08 173221" src="https://github.com/user-attachments/assets/2fbfb1c5-e69c-4266-aa9c-4b3a3712bbdd" />

