### PR TITLE
feat: define CreateTicketUseCase interface

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# Backend
+git branch -d add-pedro-spook-contributors# Backend
 
 This directory contains all backend microservices for the ITA Challenges platform.
 

--- a/backend/account-service/src/main/java/com/ita/challenges/account/application/port/in/CreateTicketUseCase.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/application/port/in/CreateTicketUseCase.java
@@ -1,0 +1,10 @@
+package com.ita.challenges.account.application.port.in;
+
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketResponse;
+
+public interface CreateTicketUseCase {
+
+    TicketResponse execute(TicketRequest request);
+
+}


### PR DESCRIPTION
**Summary**

add CreateTicketUseCase interface to establish the application layer contract using existing DTOs.

**Note**

This PR only includes the interface definition as part of the first sub-issue. Implementation will follow in a separate PR.

Closes #496