### PR TITLE
feat(auth): added API call to setUserRole

### DIFF
--- a/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
@@ -1,16 +1,68 @@
 import { TestBed } from '@angular/core/testing';
 
 import { AdminApiService } from './admin-api.service';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { Role } from '../../../core/models/role.enum';
 
 describe('AdminApiService', () => {
   let service: AdminApiService;
+  let httpMock: HttpTestingController;
+
+  const API_URL = 'http://localhost:8080/api/account/users';
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
     service = TestBed.inject(AdminApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should POST to the correct URL', () => {
+    const username = 'test';
+    const role = Role.MENTOR;
+    
+    service.setUserRole(username, role).subscribe();
+
+    const req = httpMock.expectOne(API_URL);
+    expect(req.request.method).toBe('POST');
+    req.flush(null);
+  });
+
+  it('should send the correct payload', () => {
+    const username = 'test';
+    const role = Role.MENTOR;
+
+    service.setUserRole(username, role).subscribe();
+
+    const req = httpMock.expectOne(API_URL);
+    expect(req.request.body).toEqual({ username, role });
+    req.flush(null);
+  });
+
+  it('should return an observable that completes on success', () => {
+    const username = 'test';
+    const role = Role.MENTOR;
+    let completed = false;
+
+    service.setUserRole(username, role).subscribe({
+      complete: () => (completed = true),
+    });
+
+    httpMock.expectOne(API_URL).flush(null);
+    expect(completed).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/admin/data-access/admin-api.service.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.ts
@@ -1,13 +1,20 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Role } from '../../../core/models/role.enum';
+import { Observable} from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { IUser } from '../../../shared/models/iuser.interface';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AdminApiService {
   
-  setUserRole(username: string, role: Role){
-    return
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = 'http://localhost:8080/api/account/users';
+
+  setUserRole(username: string, role: Role): Observable<void> {
+    const user: IUser = {username: username, role: role};
+    return this.http.post<void>(this.apiUrl, user);
   }
 
 }


### PR DESCRIPTION
## Goal

Add the necessary logic to `AdminApiService.setUserRole()` to call the `POST /users` endpoint.

## What's done

- Added the `POST /users` API call to `setUserRole()`
- Added tests