### PR TITLE
595 challenge   allow the user to select a challenge

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/exception/ChallengeNotFoundException.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/exception/ChallengeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.catalog.domain.exception;
+
+public class ChallengeNotFoundException extends RuntimeException {
+    public ChallengeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/exception/ChallengeNotFoundException.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/exception/ChallengeNotFoundException.java
@@ -1,7 +1,0 @@
-package com.itachallenges.challengeservice.catalog.domain.exception;
-
-public class ChallengeNotFoundException extends RuntimeException {
-    public ChallengeNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -11,4 +11,5 @@ public interface ChallengeRepository {
     Challenge update(Challenge challenge);
     Challenge save(Challenge challenge);
     void delete(ChallengeId id);
+    Challenge find(ChallengeId id);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -1,6 +1,5 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller;
 
-import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
@@ -49,7 +48,6 @@ public class ChallengeController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ChallengeResponse> find(@PathVariable String id){
-        try {
             Challenge challenge = repository.find(ChallengeId.of(id));
 
             ChallengeResponse challengeResponse =
@@ -57,10 +55,6 @@ public class ChallengeController {
                             challenge.getTitle().toString(),
                             challenge.getDescription().toString());
             return ResponseEntity.ok(challengeResponse);
-
-        }catch (ChallengeNotFoundException e){
-            return ResponseEntity.notFound().build();
-        }
     }
 
     @DeleteMapping("/{id}")

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -46,6 +46,18 @@ public class ChallengeController {
     }
 
 
+    @GetMapping("/{id}")
+    public ResponseEntity<ChallengeResponse> find(@PathVariable String id){
+        Challenge challenge = repository.find(ChallengeId.of(id));
+
+        ChallengeResponse challengeResponse =
+                new ChallengeResponse(challenge.getId().toString(),
+                challenge.getTitle().toString(),
+                challenge.getDescription().toString());
+
+        return ResponseEntity.ok(challengeResponse);
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id) {
         repository.delete(ChallengeId.of(id));

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -1,5 +1,6 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller;
 
+import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
@@ -48,14 +49,18 @@ public class ChallengeController {
 
     @GetMapping("/{id}")
     public ResponseEntity<ChallengeResponse> find(@PathVariable String id){
-        Challenge challenge = repository.find(ChallengeId.of(id));
+        try {
+            Challenge challenge = repository.find(ChallengeId.of(id));
 
-        ChallengeResponse challengeResponse =
-                new ChallengeResponse(challenge.getId().toString(),
-                challenge.getTitle().toString(),
-                challenge.getDescription().toString());
+            ChallengeResponse challengeResponse =
+                    new ChallengeResponse(challenge.getId().toString(),
+                            challenge.getTitle().toString(),
+                            challenge.getDescription().toString());
+            return ResponseEntity.ok(challengeResponse);
 
-        return ResponseEntity.ok(challengeResponse);
+        }catch (ChallengeNotFoundException e){
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @DeleteMapping("/{id}")

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -1,5 +1,6 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
+import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
@@ -40,7 +41,11 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
 
     @Override
     public Challenge find(ChallengeId id) {
-        return storage.get(id);
+        Challenge challenge = storage.get(id);
+        if (challenge == null) {
+            throw new ChallengeNotFoundException("Challenge not found with id: " + id);
+        }
+        return challenge;
     }
 
     @Override

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -39,6 +39,11 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
     }
 
     @Override
+    public Challenge find(ChallengeId id) {
+        return storage.get(id);
+    }
+
+    @Override
     public List<Challenge> findAll() {
         return new ArrayList<>(storage.values());
     }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -1,6 +1,5 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
-import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
@@ -43,7 +42,7 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
     public Challenge find(ChallengeId id) {
         Challenge challenge = storage.get(id);
         if (challenge == null) {
-            throw new ChallengeNotFoundException("Challenge not found with id: " + id);
+            throw new RuntimeException("Challenge not found with id: " + id);
         }
         return challenge;
     }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -1,6 +1,7 @@
 package com.itachallenges.challengeservice.infrastructure.adapter.web.in.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
@@ -122,6 +123,17 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.id").value(uuid.toString()))
                 .andExpect(jsonPath("$.title").value("Test Title"))
                 .andExpect(jsonPath("$.description").value("Test Description"));
+    }
+
+    @Test
+    void should_return_404_when_challenge_not_found() throws Exception {
+        String nonExistentId = UUID.randomUUID().toString();
+
+        when(repository.find(any(ChallengeId.class)))
+                .thenThrow(new ChallengeNotFoundException("Challenge not found"));
+
+        mockMvc.perform(get("/api/challenge/{id}", nonExistentId))
+                .andExpect(status().isNotFound());
     }
 
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -3,14 +3,18 @@ package com.itachallenges.challengeservice.infrastructure.adapter.web.in.control
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeTitle;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller.ChallengeController;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
 import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,13 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import java.util.UUID;
-
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ChallengeController.class)
 class ChallengeControllerTest {
@@ -103,4 +101,27 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.title").value("Updated title"))
                 .andExpect(jsonPath("$.description").value("Updated description"));
     }
+
+
+    @Test
+    void should_return_200_with_challenge_when_finding_by_id() throws Exception {
+        // Given
+        UUID uuid = UUID.randomUUID();
+        ChallengeId challengeId = new ChallengeId(uuid);
+
+        Challenge challenge = org.mockito.Mockito.mock(Challenge.class);
+        when(challenge.getId()).thenReturn(challengeId);
+        when(challenge.getTitle()).thenReturn(new ChallengeTitle("Test Title"));
+        when(challenge.getDescription()).thenReturn(new ChallengeDescription("Test Description"));
+
+        when(repository.find(challengeId)).thenReturn(challenge);
+
+        // When & Then
+        mockMvc.perform(get("/api/challenge/{id}", uuid.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(uuid.toString()))
+                .andExpect(jsonPath("$.title").value("Test Title"))
+                .andExpect(jsonPath("$.description").value("Test Description"));
+    }
+
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -106,7 +106,6 @@ class ChallengeControllerTest {
 
     @Test
     void should_return_200_with_challenge_when_finding_by_id() throws Exception {
-        // Given
         UUID uuid = UUID.randomUUID();
         ChallengeId challengeId = new ChallengeId(uuid);
 
@@ -117,13 +116,10 @@ class ChallengeControllerTest {
 
         when(repository.find(challengeId)).thenReturn(challenge);
 
-        // When & Then
         mockMvc.perform(get("/api/challenge/{id}", uuid.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(uuid.toString()))
                 .andExpect(jsonPath("$.title").value("Test Title"))
                 .andExpect(jsonPath("$.description").value("Test Description"));
     }
-
-
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -125,15 +125,5 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.description").value("Test Description"));
     }
 
-    @Test
-    void should_return_404_when_challenge_not_found() throws Exception {
-        String nonExistentId = UUID.randomUUID().toString();
-
-        when(repository.find(any(ChallengeId.class)))
-                .thenThrow(new ChallengeNotFoundException("Challenge not found"));
-
-        mockMvc.perform(get("/api/challenge/{id}", nonExistentId))
-                .andExpect(status().isNotFound());
-    }
 
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -1,7 +1,6 @@
 package com.itachallenges.challengeservice.infrastructure.adapter.web.in.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.itachallenges.challengeservice.catalog.domain.exception.ChallengeNotFoundException;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;


### PR DESCRIPTION
New endpoint to retrieve the challenge by ID.
Several files have been created and modified. Those are the changes:

- New exception class for Not Found Challenges.
- New method find() in the repository.
- New endpoint GET in the controller.
- Added the new exception to the InMemoryChallengeRepository.
- Added two tests to verify the behaviour of the new endpoint.