### PR TITLE
feat: allow students to save a draft answer

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -1,16 +1,31 @@
 package com.itachallenges.challengeservice.submission.application.usecase;
 
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
-    // TODO: inject SubmissionRepository
+
+    private final SubmissionRepository repository;
+
+    public SaveDraftSubmissionUseCaseHandler(SubmissionRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void execute(SaveDraftSubmissionCommand command) {
-        // TODO: create or update submission with IN_PROGRESS status
-        // TODO: save submission
+        Submission submission = Submission.createInProgress(
+                SubmissionId.generate(),
+                ChallengeId.of(command.challengeId()),
+                UserId.of(command.userId()),
+                command.code()
+        );
+        repository.save(submission);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -24,8 +24,15 @@ public class Submission {
     private Submission() {}
 
     public static Submission createInProgress(SubmissionId id, ChallengeId challengeId, UserId userId, String code) {
-        // TODO: create and return a new Submission with IN_PROGRESS status
-        return null;
+        Submission submission = new Submission();
+        submission.id = id;
+        submission.challengeId = challengeId;
+        submission.userId = userId;
+        submission.code = code;
+        submission.status = SubmissionStatus.IN_PROGRESS;
+        submission.createdAt = Instant.now();
+        submission.updatedAt = Instant.now();
+        return submission;
     }
 
     public void finalize(String code) {

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
@@ -1,5 +1,9 @@
 package com.itachallenges.challengeservice.submission.domain.valueobject;
 
 public enum SubmissionStatus {
-    IN_PROGRESS, FINAL, INCOMPLETE
+    NOT_STARTED,
+    IN_PROGRESS,
+    SUBMITTED,
+    APPROVED,
+    FAILED_REVIEW
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
@@ -15,7 +15,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
 @ExtendWith(MockitoExtension.class)
 class SaveDraftSubmissionUseCaseHandlerTest {
 
@@ -24,43 +23,29 @@ class SaveDraftSubmissionUseCaseHandlerTest {
 
     private SaveDraftSubmissionUseCaseHandler handler;
 
+    private final SaveDraftSubmissionCommand command = new SaveDraftSubmissionCommand(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "660e8400-e29b-41d4-a716-446655440000",
+            "public class Solution {}"
+    );
+
     @BeforeEach
     void setUp() {
         handler = new SaveDraftSubmissionUseCaseHandler(repository);
+        when(repository.save(any(Submission.class))).thenAnswer(i -> i.getArgument(0));
     }
-
-
 
     @Test
     void shouldSaveDraftSubmission() {
-        SaveDraftSubmissionCommand command = new SaveDraftSubmissionCommand(
-                "550e8400-e29b-41d4-a716-446655440000",
-                "660e8400-e29b-41d4-a716-446655440000",
-                "public class Solution {}"
-        );
-
-        when(repository.save(any(Submission.class))).thenAnswer(i -> i.getArgument(0));
-
         handler.execute(command);
-
         verify(repository).save(any(Submission.class));
     }
 
-
     @Test
     void shouldSaveDraftWithInProgressStatus() {
-        SaveDraftSubmissionCommand command = new SaveDraftSubmissionCommand(
-                "550e8400-e29b-41d4-a716-446655440000",
-                "660e8400-e29b-41d4-a716-446655440000",
-                "public class Solution {}"
-        );
-
-        when(repository.save(any(Submission.class))).thenAnswer(i -> i.getArgument(0));
-
         handler.execute(command);
-
         verify(repository).save(argThat(submission ->
                 submission.getStatus() == SubmissionStatus.IN_PROGRESS
         ));
     }
-    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandlerTest.java
@@ -1,14 +1,66 @@
 package com.itachallenges.challengeservice.submission.application.usecase;
 
+import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.Submission;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionStatus;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
 class SaveDraftSubmissionUseCaseHandlerTest {
 
-    // TODO: mock dependencies
-    // TODO: instantiate SaveDraftSubmissionUseCaseHandler
+    @Mock
+    private SubmissionRepository repository;
+
+    private SaveDraftSubmissionUseCaseHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new SaveDraftSubmissionUseCaseHandler(repository);
+    }
+
+
 
     @Test
     void shouldSaveDraftSubmission() {
-        // TODO: implement
+        SaveDraftSubmissionCommand command = new SaveDraftSubmissionCommand(
+                "550e8400-e29b-41d4-a716-446655440000",
+                "660e8400-e29b-41d4-a716-446655440000",
+                "public class Solution {}"
+        );
+
+        when(repository.save(any(Submission.class))).thenAnswer(i -> i.getArgument(0));
+
+        handler.execute(command);
+
+        verify(repository).save(any(Submission.class));
     }
-}
+
+
+    @Test
+    void shouldSaveDraftWithInProgressStatus() {
+        SaveDraftSubmissionCommand command = new SaveDraftSubmissionCommand(
+                "550e8400-e29b-41d4-a716-446655440000",
+                "660e8400-e29b-41d4-a716-446655440000",
+                "public class Solution {}"
+        );
+
+        when(repository.save(any(Submission.class))).thenAnswer(i -> i.getArgument(0));
+
+        handler.execute(command);
+
+        verify(repository).save(argThat(submission ->
+                submission.getStatus() == SubmissionStatus.IN_PROGRESS
+        ));
+    }
+    }


### PR DESCRIPTION
Implemented the save draft submission feature for students.

Changes:
- Updated SubmissionStatus enum with the full lifecycle states 
  (NOT_STARTED, IN_PROGRESS, SUBMITTED, APPROVED, FAILED_REVIEW)
- Implemented Submission.createInProgress() in the domain model
- Implemented SaveDraftSubmissionUseCaseHandler with SubmissionRepository injection
- Added unit tests for the use case handler

When a student saves a draft, the submission is stored with IN_PROGRESS status.

Closes #580 
Closes #579 