### PR TITLE
feat(create-button): add routerLink navigation (#601)

### DIFF
--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.html
@@ -1,3 +1,3 @@
-<button>
+<button routerLink="/challenges/create">
   Create Challenge
 </button>

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
@@ -1,8 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateButtonComponent } from './create-button';
 import { provideRouter } from '@angular/router';
-import { RouterLink } from '@angular/router';
-import { By } from '@angular/platform-browser';
 
 describe('CreateButtonComponent', () => {
   let component: CreateButtonComponent;

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateButtonComponent } from './create-button';
 import { provideRouter } from '@angular/router';
+import { RouterLink } from '@angular/router';
+import { By } from '@angular/platform-browser';
 
 describe('CreateButtonComponent', () => {
   let component: CreateButtonComponent;
@@ -29,5 +31,12 @@ describe('CreateButtonComponent', () => {
   it('should render button with text "Create Challenge"', () => {
     const button = fixture.nativeElement.querySelector('button');
     expect(button.textContent.trim()).toBe('Create Challenge');
+  });
+
+  it('should have routerLink to /challenges/create', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    
+    expect(button).toBeTruthy();
+    expect(button.getAttribute('routerLink')).toBe('/challenges/create');
   });
 });

--- a/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
+++ b/frontend/src/app/features/challenges/components/buttons/create-button/create-button.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-create-button',
   standalone: true,
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './create-button.html',
   styleUrl: './create-button.css',
 })


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/601)

## Summary

Implemented navigation for the `CreateButtonComponent` so that it redirects to the challenge creation page when clicked.

## What's included

* Added `routerLink` to `/challenges/create` in `CreateButtonComponent`
* Ensured button acts as a navigation trigger without additional logic
* Added unit test to verify `routerLink` is correctly applied to the button
* Maintained component reusability and simplicity
* Verified existing behavior is not broken

## Notes

This PR focuses only on enabling navigation via `routerLink` as required by the task. No additional behavior or logic has been introduced to keep the component lightweight and reusable.