### PR TITLE
feat(ticketing): basic frontend structure for ticketing

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -38,6 +38,10 @@ export const appRoutes: Routes = [
           import('./features/admin/admin.routes').then(m => m.ADMIN_ROUTES),
       },
       {
+        path: 'tickets',
+        loadChildren: () =>
+          import('./features/tickets/tickets.routes').then(m => m.TICKETS_ROUTES),
+      },      {
         path: '**',
         component: NotFoundPage,
       },

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TicketApiService } from './ticket-api.service';
+
+describe('TicketApiService', () => {
+  let service: TicketApiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TicketApiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ITicket } from '../models/iticket.interface';
 import { Observable, of } from 'rxjs';
-import { TICKETS_MOCK } from './tickets.mock';
+import { TICKETS_MOCK } from '../models/tickets.mock';
 import { ITicketRequest } from '../models/iticket-request.interface';
 
 @Injectable({

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ITicket } from '../models/iticket.interface';
+import { Observable, of } from 'rxjs';
+import { TICKETS_MOCK } from './tickets.mock';
+import { ITicketRequest } from '../models/iticket-request.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TicketApiService {
+
+  create(ticket: ITicketRequest): Observable<ITicket> {
+    return of( { id: '1', ...ticket} );
+  }
+
+  loadAll(): Observable<ITicket[]> {
+    return of( TICKETS_MOCK );
+  }
+}

--- a/frontend/src/app/features/tickets/data-access/tickets.mock.ts
+++ b/frontend/src/app/features/tickets/data-access/tickets.mock.ts
@@ -1,0 +1,22 @@
+import { ITicket } from '../models/iticket.interface';
+
+export const TICKETS_MOCK: ITicket[] = [
+  {
+    id: '1',
+    userId: 'primer',
+    title: 'primer titol',
+    description: 'primera descripcio',
+  },
+  {
+    id: '2',
+    userId: 'segon',
+    title: 'segon titol',
+    description: 'segona descripcio',
+  },
+  {
+    id: '3',
+    userId: 'tercer',
+    title: 'tercer titol',
+    description: 'tercera descripcio',
+  },
+];

--- a/frontend/src/app/features/tickets/models/iticket-request.interface.ts
+++ b/frontend/src/app/features/tickets/models/iticket-request.interface.ts
@@ -1,0 +1,5 @@
+export interface ITicketRequest {
+    userId: string,
+    title: string,
+    description: string,
+}

--- a/frontend/src/app/features/tickets/models/iticket.interface.ts
+++ b/frontend/src/app/features/tickets/models/iticket.interface.ts
@@ -1,0 +1,6 @@
+export interface ITicket {
+    id: string,
+    userId: string,
+    title: string,
+    description: string,
+}

--- a/frontend/src/app/features/tickets/models/tickets.mock.ts
+++ b/frontend/src/app/features/tickets/models/tickets.mock.ts
@@ -1,4 +1,4 @@
-import { ITicket } from '../models/iticket.interface';
+import { ITicket } from './iticket.interface';
 
 export const TICKETS_MOCK: ITicket[] = [
   {

--- a/frontend/src/app/features/tickets/pages/tickets-page.component.ts
+++ b/frontend/src/app/features/tickets/pages/tickets-page.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-tickets-page',
+  template: `
+    <h1>Tiquets</h1>
+    <p>Placeholder page (lazy-loaded).</p>
+  `,
+})
+export class TicketsPage {}

--- a/frontend/src/app/features/tickets/tickets.routes.ts
+++ b/frontend/src/app/features/tickets/tickets.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { TicketsPage } from './pages/tickets-page.component';
+
+export const TICKETS_ROUTES: Routes = [
+  {
+    path: '',
+    component: TicketsPage,
+  },
+];


### PR DESCRIPTION
## Goal

Create the basic frontend structure for tickets to avoid dependent issues.

## What's done

- Created the folder structure
- Added routes
- Created the `ITicket` and `ITicketRequest` interfaces
- Created the `TICKETS_MOCK`
- Created the basic `TicketApiService` with the `create(ITicketRequest)` and `loadAll()` functions
- Created the basic tickets page