### PR TITLE
feat(challenges): add role-based visibility for create button (#543)

### DIFF
--- a/frontend/src/app/features/challenges/components/role-selector/role-selector.html
+++ b/frontend/src/app/features/challenges/components/role-selector/role-selector.html
@@ -3,7 +3,7 @@
 
     <button
         class="role-selector__switch"
-        [class.role-selector__switch--active]="currentRole() === 'mentor'"
+        [class.role-selector__switch--active]="isMentor()"
         (click)="toggle()"
     >
         <span class="role-selector__thumb"></span>

--- a/frontend/src/app/features/challenges/components/role-selector/role-selector.spec.ts
+++ b/frontend/src/app/features/challenges/components/role-selector/role-selector.spec.ts
@@ -12,16 +12,34 @@ describe('RoleSelectorComponent', () => {
 
     fixture = TestBed.createComponent(RoleSelectorComponent);
     component = fixture.componentInstance;
-    await fixture.whenStable();
     fixture.detectChanges();
   });
 
-  it('should start with student role', () => {
-    expect(component.currentRole()).toBe('student');
+  it('should start as student (isMentor = false)', () => {
+    expect(component.isMentor()).toBe(false);
   });
 
-  it('should toggle role when toggle is called', () => {
+  it('should toggle to mentor when toggle is called', () => {
     component.toggle();
-    expect(component.currentRole()).toBe('mentor');
+    expect(component.isMentor()).toBe(true);
+  });
+
+  it('should toggle back to student on second call', () => {
+    component.toggle();
+    component.toggle();
+    expect(component.isMentor()).toBe(false);
+  });
+
+  it('should emit true when toggled to mentor', () => {
+    const emitSpy = vi.spyOn(component.roleChange, 'emit');
+    component.toggle();
+    expect(emitSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('should emit false when toggled back to student', () => {
+    const emitSpy = vi.spyOn(component.roleChange, 'emit');
+    component.toggle();
+    component.toggle();
+    expect(emitSpy).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/src/app/features/challenges/components/role-selector/role-selector.ts
+++ b/frontend/src/app/features/challenges/components/role-selector/role-selector.ts
@@ -1,6 +1,4 @@
-import { Component, signal } from '@angular/core';
-
-type Role = 'mentor' | 'student';
+import { Component, output, signal } from '@angular/core';
 
 @Component({
   selector: 'app-role-selector',
@@ -10,15 +8,13 @@ type Role = 'mentor' | 'student';
   styleUrl: './role-selector.css',
 })
 export class RoleSelectorComponent {
-  private readonly _role = signal<Role>('student');
 
-  currentRole = this._role.asReadonly();
+  isMentor = signal(false);
+
+  roleChange = output<boolean>();
 
   toggle(): void {
-    this._role.set(
-      this._role() === 'mentor'
-        ? 'student'
-        : 'mentor'
-    );
+    this.isMentor.update( currentRole => !currentRole);
+    this.roleChange.emit(this.isMentor());
   }
 }

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.css
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.css
@@ -1,0 +1,6 @@
+.challenges-list__header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -1,8 +1,14 @@
-<h1>Llistat de Reptes</h1>
+<div class="challenges-list__header">
+    <h1>Llistat de Reptes</h1>
 
+    <app-role-selector
+        (roleChange)="onRoleChange($event)"
+    ></app-role-selector>
+</div>
 
-<app-role-selector></app-role-selector>
-<app-create-button></app-create-button>
+@if(isMentor()) {
+    <app-create-button></app-create-button>
+}
 
 @if (challenges().length > 0) {
 <ul>

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -6,6 +6,7 @@ import { provideRouter } from '@angular/router';
 import { ChallengesListPage } from './challenges-list-page';
 import { ChallengeService } from '../../services/challenge.service';
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
+import { RoleSelectorComponent } from '../../components/role-selector/role-selector';
 import { CHALLENGES_MOCK } from '../../models/challenges.mock';
 
 describe('ChallengesListPage', () => {
@@ -40,15 +41,36 @@ describe('ChallengesListPage', () => {
   });
 
   it('should render challenges in the template', () => {
-    const compiled = fixture.nativeElement as HTMLElement;
-    const listItems = compiled.querySelectorAll('li');
+    const listItems = fixture.nativeElement.querySelectorAll('li');
 
     expect(listItems.length).toBe(CHALLENGES_MOCK.length);
     expect(listItems[0].textContent).toContain(CHALLENGES_MOCK[0].title);
   });
 
-  it('should render create button component', () => {
+  it('should render role selector component', () => {
+    const roleSelector = fixture.debugElement.query(By.directive(RoleSelectorComponent));
+    expect(roleSelector).toBeTruthy();
+  });
+
+  it('should not render create button when student', () => {
+    component.isMentor.set(false);
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.directive(CreateButtonComponent));
+    expect(button).toBeNull();
+  });
+
+  it('should render create button when mentor', () => {
+    component.isMentor.set(true);
+    fixture.detectChanges();
     const button = fixture.debugElement.query(By.directive(CreateButtonComponent));
     expect(button).toBeTruthy();
+  });
+
+  it('should update isMentor when onRoleChange is called', () => {
+    component.onRoleChange(true);
+    expect(component.isMentor()).toBe(true);
+
+    component.onRoleChange(false);
+    expect(component.isMentor()).toBe(false);
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -6,24 +6,34 @@ import { CreateButtonComponent } from '../../components/buttons/create-button/cr
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [CreateButtonComponent,  RoleSelectorComponent],
+  standalone: true,
+  imports: [
+    CreateButtonComponent, 
+    RoleSelectorComponent
+  ],
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
 })
 export class ChallengesListPage implements OnInit {
 
   private readonly challengesService = inject(ChallengeService);
+
   challenges = signal<IChallenge[]>([]);
+  isMentor = signal(false);
 
   ngOnInit(): void {
     this.loadChallenges();
   }
-  
-  loadChallenges(){
+
+  loadChallenges(): void {
     this.challengesService.loadAll().subscribe({
       next: (result) => {
         this.challenges.set(result);
       }
     });
+  }
+
+  onRoleChange(value: boolean): void {
+    this.isMentor.set(value);
   }
 }


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/543)

## Summary

Implemented mentor-based visibility for `CreateButtonComponent` by connecting `RoleSelectorComponent` with `ChallengesListPage`.

To support this interaction cleanly, the role selector logic was simplified from a typed role model (`'mentor' | 'student'`) to a direct boolean state (`isMentor`) that can be emitted and consumed by the parent page.

## What's included

**RoleSelectorComponent:**

* Simplified internal role state to a boolean (`isMentor`)
* Replaced typed role comparisons with direct boolean-based toggle logic
* Exposed role changes through `output<boolean>()`
* Emits updated mentor state to parent components

**ChallengesListPage:**

* Added local `isMentor` signal to react to role changes
* Connected `RoleSelectorComponent` through `(roleChange)`
* Conditionally renders `CreateButtonComponent` only when mentor mode is active
* Added basic header layout to group page title and role selector

## Notes

The role selector changes are part of the same feature flow, since the parent page visibility logic depends on how role state is exposed and communicated.

Role state is currently managed locally at page level for simplicity. A shared service could be introduced later if role management becomes global (e.g. backend-provided user roles).