### PR TITLE
Feat/545 navigation to detail

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -1,7 +1,7 @@
-@if (challenge) {
+@if (challenge()) {
 
-  <h1>{{ challenge.title }}</h1>
-  <p>{{ challenge.description}}</p>
+  <h1>{{ challenge()?.title }}</h1>
+  <p>{{ challenge()?.description}}</p>
   <textarea
       id="challengeAnswer"
       rows="10"

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -1,14 +1,6 @@
 @if (challenge()) {
-
   <h1>{{ challenge()?.title }}</h1>
   <p>{{ challenge()?.description}}</p>
-  <textarea
-      id="challengeAnswer"
-      rows="10"
-      placeholder="Escriu aquí la resposta del repte...">
-    </textarea>
-
+  <textarea id="challengeAnswer" rows="10" placeholder="Escriu aquí la resposta del repte..."></textarea>
   <button>Enviar</button>
-
 }
-

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -1,38 +1,51 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { ChallengeDetailPage } from './challenge-detail-page';
+import { ChallengeService } from '../../services/challenge.service';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
 
 describe('ChallengeDetailPage', () => {
   let component: ChallengeDetailPage;
   let fixture: ComponentFixture<ChallengeDetailPage>;
+  let mockChallengeService: any;
+  let mockActivatedRoute: any;
+
+  const mockChallenge = {
+    id: 'test-123',
+    title: 'Test Challenge',
+    description: 'Test Description'
+  };
 
   beforeEach(async () => {
+    mockChallengeService = { getById: vi.fn().mockReturnValue(of(mockChallenge)) };
+    mockActivatedRoute = { snapshot: { paramMap: { get: vi.fn().mockReturnValue('test-123') } } };
+
     await TestBed.configureTestingModule({
-      imports: [ChallengeDetailPage]
-    })
-    .compileComponents();
+      imports: [ChallengeDetailPage],
+      providers: [
+        { provide: ChallengeService, useValue: mockChallengeService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChallengeDetailPage);
     component = fixture.componentInstance;
-    await fixture.whenStable();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should render challenge data from mock', () => {
-    const mockChallenge = {
-      id: '1',
-      title: 'primer',
-      description: 'descripció 1',
-    };
-
-    component.challenge = mockChallenge;
+  it('should load challenge on init', async () => {
     fixture.detectChanges();
-    
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(mockChallenge.title);
-    expect(compiled.querySelector('p')?.textContent).toContain(mockChallenge.description);
+    await fixture.whenStable();
+
+    expect(component.challenge()).toEqual(mockChallenge);
+  });
+
+  it('should render details', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement;
+    expect(compiled.querySelector('h1').textContent).toContain('Test Challenge');
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -39,13 +39,4 @@ describe('ChallengeDetailPage', () => {
 
     expect(component.challenge()).toEqual(mockChallenge);
   });
-
-  it('should render details', async () => {
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Test Challenge');
-  });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { ChallengeService } from '../../services/challenge.service';
+import { ActivatedRoute } from '@angular/router';
 import { IChallenge } from '../../models/ichallenge.interface';
-import { CHALLENGES_MOCK } from '../../models/challenges.mock';
 
 @Component({
   selector: 'app-challenge-detail-page',
@@ -10,6 +11,19 @@ import { CHALLENGES_MOCK } from '../../models/challenges.mock';
 })
 export class ChallengeDetailPage {
 
-  challenge: IChallenge = CHALLENGES_MOCK[0];
+  private readonly challengesService = inject(ChallengeService);
+  private readonly route = inject(ActivatedRoute)
+
+  challenge = signal<IChallenge | undefined>(undefined);
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id')!;
+
+    this.challengesService.getById(id).subscribe( (selectedChallenge) => {
+      this.challenge.set(selectedChallenge)
+    })
+
+
+  }
 
 }

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -22,8 +22,5 @@ export class ChallengeDetailPage {
     this.challengesService.getById(id).subscribe( (selectedChallenge) => {
       this.challenge.set(selectedChallenge)
     })
-
-
   }
-
 }

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -1,15 +1,12 @@
 <h1>Llistat de Reptes</h1>
 
-
-<app-role-selector></app-role-selector>
-<app-create-button></app-create-button>
-
 @if (challenges().length > 0) {
 <ul>
     @for (challenge of challenges(); track $index) {
     <li>
         <h2>{{ challenge.title }}</h2>
         <p>{{ challenge.description }}</p>
+        <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
     </li>
     }
 </ul>

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -9,7 +9,6 @@
     <li>
         <h2>{{ challenge.title }}</h2>
         <p>{{ challenge.description }}</p>
-        <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
     </li>
     }
 </ul>

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -1,12 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { By } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
-
 import { ChallengesListPage } from './challenges-list-page';
 import { ChallengeService } from '../../services/challenge.service';
-import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
 import { CHALLENGES_MOCK } from '../../models/challenges.mock';
+import { provideRouter } from '@angular/router';
 
 describe('ChallengesListPage', () => {
   let component: ChallengesListPage;
@@ -14,20 +11,22 @@ describe('ChallengesListPage', () => {
   let mockChallengeService: any;
 
   beforeEach(async () => {
-    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK))};
+    mockChallengeService = {
+      loadAll: () => of(CHALLENGES_MOCK)
+    };
 
     await TestBed.configureTestingModule({
       imports: [ChallengesListPage],
       providers: [
-        provideRouter([]),
-        { provide: ChallengeService, useValue: mockChallengeService }
+        { provide: ChallengeService, useValue: mockChallengeService },
+        provideRouter([])
       ]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(ChallengesListPage);
     component = fixture.componentInstance;
-    fixture.detectChanges(); 
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -35,20 +34,13 @@ describe('ChallengesListPage', () => {
   });
 
   it('should load challenges on initialization', () => {
-    expect(mockChallengeService.loadAll).toHaveBeenCalled();
     expect(component.challenges()).toEqual(CHALLENGES_MOCK);
   });
 
   it('should render challenges in the template', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const listItems = compiled.querySelectorAll('li');
-
     expect(listItems.length).toBe(CHALLENGES_MOCK.length);
     expect(listItems[0].textContent).toContain(CHALLENGES_MOCK[0].title);
-  });
-
-  it('should render create button component', () => {
-    const button = fixture.debugElement.query(By.directive(CreateButtonComponent));
-    expect(button).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,13 +1,12 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
-import { RouterLink } from '@angular/router';
 import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
 import { CreateButtonComponent } from "../../components/buttons/create-button/create-button";
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [RouterLink, RoleSelectorComponent, CreateButtonComponent],
+  imports: [RoleSelectorComponent, CreateButtonComponent],
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
 })

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,12 +1,11 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
-import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
-import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [CreateButtonComponent,  RoleSelectorComponent],
+  imports: [RouterLink],
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
 })
@@ -18,7 +17,7 @@ export class ChallengesListPage implements OnInit {
   ngOnInit(): void {
     this.loadChallenges();
   }
-  
+
   loadChallenges(){
     this.challengesService.loadAll().subscribe({
       next: (result) => {

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -7,11 +7,7 @@ import { CreateButtonComponent } from "../../components/buttons/create-button/cr
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [
-    RouterLink,
-    RoleSelectorComponent,
-    CreateButtonComponent
-  ],
+  imports: [RouterLink, RoleSelectorComponent, CreateButtonComponent],
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
 })

--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { vi } from 'vitest';
 import { ChallengeService } from './challenge.service';
 import { ChallengeApiService } from '../data-access/challenge-api.service';
@@ -94,5 +94,28 @@ describe('ChallengeService', () => {
       result = challenges;
     });
     expect(result).toEqual(CHALLENGES_MOCK);
+  });
+
+  describe('getById', () => {
+    it('should return the correct challenge when id exists', async () => {
+      const targetId = CHALLENGES_MOCK[0].id;
+      const challenge = await firstValueFrom(service.getById(targetId));
+
+      expect(challenge).toEqual(CHALLENGES_MOCK[0]);
+    });
+
+    it('should return undefined when id does not exist', async () => {
+      const challenge = await firstValueFrom(service.getById('inexistente'));
+
+      expect(challenge).toBeUndefined();
+    });
+
+    it('should call loadAll from ApiService', () => {
+      const spy = vi.spyOn(mockChallengeApiService, 'loadAll');
+
+      service.getById('1').subscribe();
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/app/features/challenges/services/challenge.service.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { IChallengeRequest } from '../models/ichallenge-request.interface';
 import { IChallenge } from '../models/ichallenge.interface';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import { ChallengeApiService } from '../data-access/challenge-api.service';
 
 @Injectable({
@@ -25,5 +25,11 @@ export class ChallengeService {
   }
 
   delete(id: string): Observable<void> { return this.challengeApiService.delete(id) }
+
+  getById(id: string): Observable<IChallenge | undefined> {
+    return this.challengeApiService.loadAll().pipe(
+      map((challenges) => challenges.find(((challenge) => challenge.id === id)))
+    )
+  }
 
 }


### PR DESCRIPTION
[Task here](https://github.com/IT-Academy-BCN/ita-challenges/issues/545)
**Objective:** Make each challenge item in the list clickable, redirecting to its specific detail view using its id.

### Changes Included
- HTML: Replaced static content with a [routerLink] button in ChallengesListPage.
- Service: Added getById(id) method to ChallengeService.
- Routes: Defined the dynamic route :id in CHALLENGES_ROUTES.
