### PR TITLE
Feat/json file challenge storage 593

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -41,13 +41,11 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
 
     @Override
     public Challenge update(Challenge challenge) {
-        // TODO: implement in future sprint
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override
     public void delete(ChallengeId id) {
-        // TODO: implement in future sprint
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -37,7 +37,12 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
         persistToFile();
         return challenge;
     }
-
+    
+    @Override
+    public Challenge find(ChallengeId id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+    
     @Override
     public Challenge update(Challenge challenge) {
         throw new UnsupportedOperationException("Not implemented yet");

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -1,0 +1,93 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Primary
+@Repository
+public class JsonFileChallengeRepository implements ChallengeRepository {
+
+    private final File storageFile;
+    private final ObjectMapper objectMapper;
+    private final Map<ChallengeId, Challenge> storage = new ConcurrentHashMap<>();
+
+    public JsonFileChallengeRepository(
+            @Value("${challenge.storage.file-path:challenges.json}") String filePath,
+            ObjectMapper objectMapper) {
+        this.storageFile = new File(filePath);
+        this.objectMapper = objectMapper;
+        loadFromFile();
+    }
+
+    @Override
+    public Challenge save(Challenge challenge) {
+        storage.put(challenge.getId(), challenge);
+        persistToFile();
+        return challenge;
+    }
+
+    @Override
+    public Challenge update(Challenge challenge) {
+        // TODO: implement in future sprint
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public void delete(ChallengeId id) {
+        // TODO: implement in future sprint
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public List<Challenge> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+
+    private void persistToFile() {
+        try {
+            List<ChallengeRecord> records = storage.values().stream()
+                    .map(c -> new ChallengeRecord(
+                            c.getId().toString(),
+                            c.getTitle().toString(),
+                            c.getDescription().toString()
+                    ))
+                    .toList();
+            objectMapper.writeValue(storageFile, records);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to persist challenges to file", e);
+        }
+    }
+
+    private void loadFromFile() {
+        if (!storageFile.exists()) return;
+        try {
+            List<ChallengeRecord> records = objectMapper.readValue(
+                    storageFile, new TypeReference<>() {});
+            records.forEach(r -> {
+                Challenge challenge = Challenge.restore(
+                        ChallengeId.of(r.id()),
+                        r.title(),
+                        r.description()
+                );
+                storage.put(challenge.getId(), challenge);
+            });
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load challenges from file", e);
+        }
+    }
+
+    record ChallengeRecord(String id, String title, String description) {}
+}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -26,16 +26,26 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
 
     public JsonFileChallengeRepository(
             @Value("${challenge.storage.file-path:challenges.json}") String filePath,
-            ObjectMapper objectMapper) throws IOException {
+            ObjectMapper objectMapper) {
+
         this.storageFile = new File(filePath);
         this.objectMapper = objectMapper;
-        loadFromFile();
+
+        try {
+            loadFromFile();
+        } catch (IOException ignored) {
+        }
     }
 
     @Override
-    public Challenge save(Challenge challenge) throws IOException {
+    public Challenge save(Challenge challenge) {
         storage.put(challenge.getId(), challenge);
-        persistToFile();
+
+        try {
+            persistToFile();
+        } catch (IOException ignored) {
+        }
+
         return challenge;
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,37 +53,29 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
         return new ArrayList<>(storage.values());
     }
 
-    private void persistToFile() {
-        try {
-            List<ChallengeRecord> records = storage.values().stream()
-                    .map(c -> new ChallengeRecord(
-                            c.getId().toString(),
-                            c.getTitle().toString(),
-                            c.getDescription().toString()
-                    ))
-                    .toList();
-            objectMapper.writeValue(storageFile, records);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to persist challenges to file", e);
-        }
+    private void persistToFile() throws Exception {
+        List<ChallengeRecord> records = storage.values().stream()
+                .map(c -> new ChallengeRecord(
+                        c.getId().toString(),
+                        c.getTitle().toString(),
+                        c.getDescription().toString()
+                ))
+                .toList();
+        objectMapper.writeValue(storageFile, records);
     }
 
-    private void loadFromFile() {
+    private void loadFromFile() throws Exception {
         if (!storageFile.exists()) return;
-        try {
-            List<ChallengeRecord> records = objectMapper.readValue(
-                    storageFile, new TypeReference<>() {});
-            records.forEach(r -> {
-                Challenge challenge = Challenge.restore(
-                        ChallengeId.of(r.id()),
-                        r.title(),
-                        r.description()
-                );
-                storage.put(challenge.getId(), challenge);
-            });
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to load challenges from file", e);
-        }
+        List<ChallengeRecord> records = objectMapper.readValue(
+                storageFile, new TypeReference<>() {});
+        records.forEach(r -> {
+            Challenge challenge = Challenge.restore(
+                    ChallengeId.of(r.id()),
+                    r.title(),
+                    r.description()
+            );
+            storage.put(challenge.getId(), challenge);
+        });
     }
 
     record ChallengeRecord(String id, String title, String description) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,24 +26,24 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
 
     public JsonFileChallengeRepository(
             @Value("${challenge.storage.file-path:challenges.json}") String filePath,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper) throws IOException {
         this.storageFile = new File(filePath);
         this.objectMapper = objectMapper;
         loadFromFile();
     }
 
     @Override
-    public Challenge save(Challenge challenge) {
+    public Challenge save(Challenge challenge) throws IOException {
         storage.put(challenge.getId(), challenge);
         persistToFile();
         return challenge;
     }
-    
+
     @Override
     public Challenge find(ChallengeId id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return storage.get(id);
     }
-    
+
     @Override
     public Challenge update(Challenge challenge) {
         throw new UnsupportedOperationException("Not implemented yet");
@@ -58,29 +59,25 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
         return new ArrayList<>(storage.values());
     }
 
-    private void persistToFile() throws Exception {
-        List<ChallengeRecord> records = storage.values().stream()
+    private void persistToFile() throws IOException {
+        objectMapper.writeValue(storageFile, storage.values().stream()
                 .map(c -> new ChallengeRecord(
                         c.getId().toString(),
                         c.getTitle().toString(),
-                        c.getDescription().toString()
-                ))
-                .toList();
-        objectMapper.writeValue(storageFile, records);
+                        c.getDescription().toString()))
+                .toList());
     }
 
-    private void loadFromFile() throws Exception {
+    private void loadFromFile() throws IOException {
         if (!storageFile.exists()) return;
-        List<ChallengeRecord> records = objectMapper.readValue(
-                storageFile, new TypeReference<>() {});
-        records.forEach(r -> {
-            Challenge challenge = Challenge.restore(
-                    ChallengeId.of(r.id()),
-                    r.title(),
-                    r.description()
-            );
-            storage.put(challenge.getId(), challenge);
-        });
+
+        objectMapper.readValue(storageFile, new TypeReference<List<ChallengeRecord>>() {})
+                .forEach(r -> storage.put(
+                        ChallengeId.of(r.id()),
+                        Challenge.restore(
+                                ChallengeId.of(r.id()),
+                                r.title(),
+                                r.description())));
     }
 
     record ChallengeRecord(String id, String title, String description) {}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -12,3 +12,7 @@ management:
         enabled: true
 server:
   port: ${SERVER_PORT:8080}
+
+  challenge:
+    storage:
+      file-path: ${CHALLENGE_STORAGE_FILE:challenges.json}

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -13,6 +13,6 @@ management:
 server:
   port: ${SERVER_PORT:8080}
 
-  challenge:
-    storage:
-      file-path: ${CHALLENGE_STORAGE_FILE:challenges.json}
+challenge:
+  storage:
+    file-path: ${CHALLENGE_STORAGE_FILE:challenges.json}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonFileChallengeRepositoryTest {
+
+    private static final String TEST_FILE = "challenges-test.json";
+    private JsonFileChallengeRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new JsonFileChallengeRepository(TEST_FILE, new ObjectMapper());
+    }
+
+    @AfterEach
+    void cleanUp() {
+        new File(TEST_FILE).delete();
+    }
+
+    @Test
+    void save_should_store_challenge_in_json_file() {
+        Challenge challenge = Challenge.create("Clean Code", "Write readable code");
+
+        repository.save(challenge);
+
+        assertThat(new File(TEST_FILE)).exists();
+        assertThat(repository.findAll()).hasSize(1);
+        assertThat(repository.findAll().get(0).getTitle().toString()).isEqualTo("Clean Code");
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -7,17 +7,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonFileChallengeRepositoryTest {
 
     private static final String TEST_FILE = "challenges-test.json";
+
     private JsonFileChallengeRepository repository;
 
     @BeforeEach
-    void setUp() {
-        repository = new JsonFileChallengeRepository(TEST_FILE, new ObjectMapper());
+    void setUp() throws IOException {
+        repository = new JsonFileChallengeRepository(
+                TEST_FILE,
+                new ObjectMapper()
+        );
     }
 
     @AfterEach
@@ -26,13 +31,18 @@ class JsonFileChallengeRepositoryTest {
     }
 
     @Test
-    void save_should_store_challenge_in_json_file() {
-        Challenge challenge = Challenge.create("Clean Code", "Write readable code");
+    void save_should_store_challenge_in_json_file() throws IOException {
+
+        Challenge challenge = Challenge.create(
+                "Clean Code",
+                "Write readable code"
+        );
 
         repository.save(challenge);
 
         assertThat(new File(TEST_FILE)).exists();
         assertThat(repository.findAll()).hasSize(1);
-        assertThat(repository.findAll().get(0).getTitle().toString()).isEqualTo("Clean Code");
+        assertThat(repository.findAll().get(0).getTitle().toString())
+                .isEqualTo("Clean Code");
     }
 }


### PR DESCRIPTION
## What this PR does

This PR adds a simple file-based storage system for challenges.

Instead of keeping challenges only while the application is running, they are now saved into a JSON file on disk. This means:

- Challenges are kept even after restarting the application
- Existing challenges are automatically loaded again when the app starts
- The file location can be changed using the `CHALLENGE_STORAGE_FILE` environment variable

In simple terms, the application now remembers the challenges instead of losing them on every restart.

The initial load `challenges.json` seed file is managed in #594.

Closes #593  
Related to #587