### PR TITLE
feat: add ticket repository contract

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
@@ -2,10 +2,6 @@ package com.ita.challenges.account.domain.port.out;
 
 import com.ita.challenges.account.domain.model.Ticket;
 
-import java.util.List;
-
 public interface TicketRepository {
-    List<Ticket> findAllByUserId(String userId);
-
-    Ticket updateTicket(Ticket ticket);
+    Ticket save(Ticket newTicket);
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
@@ -4,25 +4,16 @@ import com.ita.challenges.account.domain.model.Ticket;
 import com.ita.challenges.account.domain.port.out.TicketRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryTicketRepository implements TicketRepository {
-
-    private final Map<String, Ticket> storage = new ConcurrentHashMap<>();
-
-    @Override
-    public List<Ticket> findAllByUserId(String userId) {
-        return new ArrayList<>(storage.values().stream()
-                .filter(ticket -> ticket.getUserId().equals(userId))
-                .toList());
-    }
+    private final Map<String, Ticket> database = new HashMap<>();
 
     @Override
-    public Ticket updateTicket(Ticket ticket) {
-        throw new UnsupportedOperationException("updateTicket not implemented yet");
+    public Ticket save(Ticket newTicket) {
+        database.put(newTicket.getId(), newTicket);
+        return newTicket;
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -1,35 +1,26 @@
 package com.ita.challenges.account.infrastructure.adapter.web.out.persistence;
 
 import com.ita.challenges.account.domain.model.Ticket;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class InMemoryTicketRepositoryTest {
 
-    private final InMemoryTicketRepository repository = new InMemoryTicketRepository();
+    private InMemoryTicketRepository repository;
 
-    @Test
-    void should_return_empty_list_when_no_tickets_exist_for_user() {
-
-        List<Ticket> result = repository.findAllByUserId("user-1");
-
-        assertThat(result).isEmpty();
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryTicketRepository();
     }
 
     @Test
-    void updateTicket_should_throw_unsupported_operation_exception() {
+    void should_save_a_ticket() {
+        Ticket ticket = Ticket.create("12345678", "Test Title", "Test Description");
 
-        Ticket ticket = Ticket.create("user-1", "Update Task", "Description");
-
-        UnsupportedOperationException exception =
-                assertThrows(UnsupportedOperationException.class,
-                        () -> repository.updateTicket(ticket));
-
-        assertEquals("updateTicket not implemented yet", exception.getMessage());
+        assertDoesNotThrow(() -> {
+            repository.save(ticket);
+        });
     }
 }


### PR DESCRIPTION
Closes #497

### Description
This PR adds the `TicketRepository` interface to define the contract for ticket persistence in the domain layer.

### ⚠️ Note to reviewers
As requested, I have split my original branch into three separate PRs to follow the "1 issue = 1 PR" workflow. 