### PR TITLE
Feature/498 add in-memory ticket adapter

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
@@ -2,10 +2,6 @@ package com.ita.challenges.account.domain.port.out;
 
 import com.ita.challenges.account.domain.model.Ticket;
 
-import java.util.List;
-
 public interface TicketRepository {
-    List<Ticket> findAllByUserId(String userId);
-
-    Ticket updateTicket(Ticket ticket);
+    Ticket save(Ticket newTicket);
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
@@ -4,25 +4,16 @@ import com.ita.challenges.account.domain.model.Ticket;
 import com.ita.challenges.account.domain.port.out.TicketRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 public class InMemoryTicketRepository implements TicketRepository {
-
-    private final Map<String, Ticket> storage = new ConcurrentHashMap<>();
-
-    @Override
-    public List<Ticket> findAllByUserId(String userId) {
-        return new ArrayList<>(storage.values().stream()
-                .filter(ticket -> ticket.getUserId().equals(userId))
-                .toList());
-    }
+    private final Map<String, Ticket> database = new HashMap<>();
 
     @Override
-    public Ticket updateTicket(Ticket ticket) {
-        throw new UnsupportedOperationException("updateTicket not implemented yet");
+    public Ticket save(Ticket newTicket) {
+        database.put(newTicket.getId(), newTicket);
+        return newTicket;
     }
 }


### PR DESCRIPTION
Closes #498

### Description
This PR adds the `InMemoryTicketRepository` adapter to implement the ticket persistence contract.

### ⚠️ Note to reviewers
This is part 2 of 3 of the split workflow. 
**Important: This PR depends on the Contract PR.** Please make sure to review and approve the contract first.