### PR TITLE
feat(frontend): wire ticket creation API to backend POST

### DIFF
--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -1,11 +1,11 @@
-import {TestBed} from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import {provideHttpClient} from '@angular/common/http';
-import {TicketApiService} from './ticket-api.service';
-import {TICKETS_MOCK} from '../models/tickets.mock';
+import { provideHttpClient } from '@angular/common/http';
+import { TicketApiService } from './ticket-api.service';
+import { TICKETS_MOCK } from '../models/tickets.mock';
 
 describe('TicketApiService', () => {
   let service: TicketApiService;
@@ -17,7 +17,7 @@ describe('TicketApiService', () => {
     description: 'Issue description',
   };
 
-  const mockTicketResponse = {id: '1', ...mockTicket}
+  const mockTicketResponse = { id: '1', ...mockTicket}
 
   const API_URL = '/api/accounts/tickets';
 
@@ -104,6 +104,6 @@ describe('TicketApiService', () => {
       statusText: 'Server Error',
     });
 
-    expect(result).toEqual({id: '1', ...mockTicket});
+    expect(result).toEqual({ id: '1', ...mockTicket });
   });
 });

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -11,6 +11,14 @@ describe('TicketApiService', () => {
   let service: TicketApiService;
   let httpMock: HttpTestingController;
 
+  const mockTicket = {
+    userId: 'u-1',
+    title: 'Issue title',
+    description: 'Issue description',
+  };
+
+  const mockTicketResponse = { id: '1', ...mockTicket}
+
   const API_URL = '/api/accounts/tickets';
 
   beforeEach(() => {
@@ -55,48 +63,31 @@ describe('TicketApiService', () => {
   });
 
   it('should POST to the correct URL', () => {
-    const ticket = {
-      userId: 'u-1',
-      title: 'Issue title',
-      description: 'Issue description',
-    };
 
-    service.create(ticket).subscribe();
+    service.create(mockTicket).subscribe();
 
     const req = httpMock.expectOne(API_URL);
     expect(req.request.method).toBe('POST');
+    req.flush(mockTicketResponse);
   });
 
   it('should send the correct payload', () => {
-    const ticket = {
-      userId: 'u-1',
-      title: 'Issue title',
-      description: 'Issue description',
-    };
-
-    service.create(ticket).subscribe();
+    service.create(mockTicket).subscribe();
 
     const req = httpMock.expectOne(API_URL);
-    expect(req.request.body).toEqual(ticket);
-    req.flush({ id: '1', ...ticket });
+    expect(req.request.body).toEqual(mockTicket);
+    req.flush(mockTicketResponse);
   });
 
   it('should return backend data on success', () => {
-    const ticket = {
-      userId: 'u-1',
-      title: 'Issue title',
-      description: 'Issue description',
-    };
+    let result;
 
-    const response = { id: '1', ...ticket };
-    let result: any;
-
-    service.create(ticket).subscribe((value) => {
+    service.create(mockTicket).subscribe((value) => {
       result = value;
     });
 
-    httpMock.expectOne(API_URL).flush(response);
+    httpMock.expectOne(API_URL).flush(mockTicketResponse);
 
-    expect(result).toEqual(response);
+    expect(result).toEqual(mockTicketResponse);
   });
 });

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -9,11 +9,11 @@ import { TicketApiService } from './ticket-api.service';
 import { TICKETS_MOCK } from '../models/tickets.mock';
 
 describe('TicketApiService', () => {
-
   let service: TicketApiService;
   let httpMock: HttpTestingController;
 
   const API_URL = '/api/accounts/tickets';
+
   beforeEach(() => {
 
     TestBed.configureTestingModule({
@@ -22,7 +22,6 @@ describe('TicketApiService', () => {
         provideHttpClientTesting(),
       ],
     });
-
     service = TestBed.inject(TicketApiService);
     httpMock = TestBed.inject(HttpTestingController);
   });
@@ -51,11 +50,56 @@ describe('TicketApiService', () => {
     service.loadAll().subscribe((tickets) => {
       expect(tickets).toEqual(TICKETS_MOCK);
     });
-
     const req = httpMock.expectOne(API_URL);
     req.flush('Error', {
       status: 500,
       statusText: 'Server Error',
     });
+  });
+
+  it('should POST to the correct URL', () => {
+    const ticket = {
+      userId: 'u-1',
+      title: 'Issue title',
+      description: 'Issue description',
+    };
+
+    service.create(ticket).subscribe();
+
+    const req = httpMock.expectOne(API_URL);
+    expect(req.request.method).toBe('POST');
+  });
+
+  it('should send the correct payload', () => {
+    const ticket = {
+      userId: 'u-1',
+      title: 'Issue title',
+      description: 'Issue description',
+    };
+
+    service.create(ticket).subscribe();
+
+    const req = httpMock.expectOne(API_URL);
+    expect(req.request.body).toEqual(ticket);
+    req.flush({ id: '1', ...ticket });
+  });
+
+  it('should return backend data on success', () => {
+    const ticket = {
+      userId: 'u-1',
+      title: 'Issue title',
+      description: 'Issue description',
+    };
+
+    const response = { id: '1', ...ticket };
+    let result: any;
+
+    service.create(ticket).subscribe((value) => {
+      result = value;
+    });
+
+    httpMock.expectOne(API_URL).flush(response);
+
+    expect(result).toEqual(response);
   });
 });

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -1,11 +1,11 @@
-import { TestBed } from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
-import { TicketApiService } from './ticket-api.service';
-import { TICKETS_MOCK } from '../models/tickets.mock';
+import {provideHttpClient} from '@angular/common/http';
+import {TicketApiService} from './ticket-api.service';
+import {TICKETS_MOCK} from '../models/tickets.mock';
 
 describe('TicketApiService', () => {
   let service: TicketApiService;
@@ -17,7 +17,7 @@ describe('TicketApiService', () => {
     description: 'Issue description',
   };
 
-  const mockTicketResponse = { id: '1', ...mockTicket}
+  const mockTicketResponse = {id: '1', ...mockTicket}
 
   const API_URL = '/api/accounts/tickets';
 
@@ -89,5 +89,21 @@ describe('TicketApiService', () => {
     httpMock.expectOne(API_URL).flush(mockTicketResponse);
 
     expect(result).toEqual(mockTicketResponse);
+  });
+
+  it('should return fallback ticket on create error', () => {
+    let result: any;
+
+    service.create(mockTicket).subscribe((value) => {
+      result = value;
+    });
+
+    const req = httpMock.expectOne(API_URL);
+    req.flush('Error', {
+      status: 500,
+      statusText: 'Server Error',
+    });
+
+    expect(result).toEqual({id: '1', ...mockTicket});
   });
 });

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -3,7 +3,6 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
-
 import { provideHttpClient } from '@angular/common/http';
 import { TicketApiService } from './ticket-api.service';
 import { TICKETS_MOCK } from '../models/tickets.mock';
@@ -15,7 +14,6 @@ describe('TicketApiService', () => {
   const API_URL = '/api/accounts/tickets';
 
   beforeEach(() => {
-
     TestBed.configureTestingModule({
       providers: [
         provideHttpClient(),
@@ -35,7 +33,6 @@ describe('TicketApiService', () => {
   });
 
   it('should return tickets from API', () => {
-
     service.loadAll().subscribe((tickets) => {
       expect(tickets).toEqual(TICKETS_MOCK);
     });
@@ -46,10 +43,10 @@ describe('TicketApiService', () => {
   });
 
   it('should return mock tickets on API error', () => {
-
     service.loadAll().subscribe((tickets) => {
       expect(tickets).toEqual(TICKETS_MOCK);
     });
+
     const req = httpMock.expectOne(API_URL);
     req.flush('Error', {
       status: 500,

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -1,10 +1,10 @@
-import { inject, Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { catchError, Observable, of } from 'rxjs';
+import {inject, Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
+import {catchError, Observable, of} from 'rxjs';
 
-import { ITicket } from '../models/iticket.interface';
-import { ITicketRequest } from '../models/iticket-request.interface';
-import { TICKETS_MOCK } from '../models/tickets.mock';
+import {ITicket} from '../models/iticket.interface';
+import {ITicketRequest} from '../models/iticket-request.interface';
+import {TICKETS_MOCK} from '../models/tickets.mock';
 
 @Injectable({
   providedIn: 'root',
@@ -15,7 +15,7 @@ export class TicketApiService {
 
   create(ticket: ITicketRequest): Observable<ITicket> {
     return this.http.post<ITicket>(this.ticketsUrl, ticket).pipe(
-      catchError(() => of({ id: '1', ...ticket } as ITicket))
+      catchError(() => of({id: '1', ...ticket} as ITicket))
     );
   }
 

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -1,8 +1,6 @@
-import { inject, Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-
-import { catchError, Observable, of } from 'rxjs';
-
+import {HttpClient, HttpErrorResponse} from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import {catchError, Observable, of} from 'rxjs';
 import { ITicket } from '../models/iticket.interface';
 import { ITicketRequest } from '../models/iticket-request.interface';
 import { TICKETS_MOCK } from '../models/tickets.mock';
@@ -17,7 +15,12 @@ export class TicketApiService {
   private readonly ticketsUrl = '/api/accounts/tickets';
 
   create(ticket: ITicketRequest): Observable<ITicket> {
-    return of( { id: '1', userId:'one', ...ticket} );
+    return this.http.post<ITicket>(this.ticketsUrl, ticket)
+      .pipe(
+        catchError(() => {
+          return of({ id: '1', ...ticket});
+        })
+      );
   }
 
   loadAll(): Observable<ITicket[]> {

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -1,6 +1,7 @@
-import {HttpClient, HttpErrorResponse} from '@angular/common/http';
-import { Injectable, inject } from '@angular/core';
-import {catchError, Observable, of} from 'rxjs';
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { catchError, Observable, of } from 'rxjs';
+
 import { ITicket } from '../models/iticket.interface';
 import { ITicketRequest } from '../models/iticket-request.interface';
 import { TICKETS_MOCK } from '../models/tickets.mock';
@@ -9,26 +10,20 @@ import { TICKETS_MOCK } from '../models/tickets.mock';
   providedIn: 'root',
 })
 export class TicketApiService {
-
   private readonly http = inject(HttpClient);
-
   private readonly ticketsUrl = '/api/accounts/tickets';
 
   create(ticket: ITicketRequest): Observable<ITicket> {
-    return this.http.post<ITicket>(this.ticketsUrl, ticket)
-      .pipe(
-        catchError(() => {
-          return of({ id: '1', ...ticket});
-        })
-      );
+    return this.http.post<ITicket>(this.ticketsUrl, ticket).pipe(
+      catchError(() => of({ id: '1', ...ticket } as ITicket))
+    );
   }
 
   loadAll(): Observable<ITicket[]> {
-    return this.http.get<ITicket[]>(this.ticketsUrl)
-      .pipe(
-          catchError((error: HttpErrorResponse) => {
-            return of(TICKETS_MOCK);
-          })
-        );
+    return this.http.get<ITicket[]>(this.ticketsUrl).pipe(
+      catchError((error: HttpErrorResponse) => {
+        return of(TICKETS_MOCK);
+      })
+    );
   }
 }


### PR DESCRIPTION
What has been done: 

-Replace create()mock in TicketApiService by a real HTTP POST call using HttpClient and inject.
-Set up ticket endpoint URL for the create flow: http://localhost:8080/api/account/tickets
-Extend TicketApiService tests by replicating the testing approach from task #618: 
    -verifies POST method and correct URL
    -verifies sent payload
    -verifies success response from backend
