### PR TITLE
feat(auth): setup for create/update user endpoint

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/AccountApplication.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/AccountApplication.java
@@ -3,7 +3,7 @@ package com.ita.challenges.account;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 @SpringBootApplication
 public class AccountApplication {
@@ -13,7 +13,7 @@ public class AccountApplication {
 	}
 
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestClient restClient() {
+        return RestClient.create();
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/AccountApplication.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/AccountApplication.java
@@ -2,6 +2,8 @@ package com.ita.challenges.account;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class AccountApplication {
@@ -10,4 +12,8 @@ public class AccountApplication {
 		SpringApplication.run(AccountApplication.class, args);
 	}
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/User.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/User.java
@@ -17,4 +17,8 @@ public class User {
     public Role userRole() {
         return userRole;
     }
+
+    public User withRole(Role newRole) {
+        return new User(this.userName, newRole);
+    }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/UserRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/UserRepository.java
@@ -6,5 +6,6 @@ import java.util.Optional;
 
 public interface UserRepository {
     Optional<User> findByUsername(String username);
-    void save(User user);
+
+    User save(User user);
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/GitHubUserResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/GitHubUserResponse.java
@@ -1,4 +1,0 @@
-package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
-
-public record GitHubUserResponse(String id) {
-}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/GitHubUserResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/GitHubUserResponse.java
@@ -1,0 +1,4 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
+
+public record GitHubUserResponse(String id) {
+}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/dto/GitHubUserResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/dto/GitHubUserResponse.java
@@ -1,0 +1,4 @@
+package com.ita.challenges.account.infrastructure.adapter.web.out.dto;
+
+public record GitHubUserResponse(String id) {
+}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
@@ -2,11 +2,13 @@ package com.ita.challenges.account.infrastructure.adapter.web.out.persistence;
 
 import com.ita.challenges.account.domain.model.User;
 import com.ita.challenges.account.domain.port.out.UserRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+@Repository
 public class InMemoryUserRepository implements UserRepository {
     final ConcurrentMap<String, User> storage = new ConcurrentHashMap<>();
 

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
@@ -18,7 +18,8 @@ public class InMemoryUserRepository implements UserRepository {
     }
 
     @Override
-    public void save(User user) {
+    public User save(User user) {
         storage.put(user.userName(), user);
+        return user;
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/UserTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/UserTest.java
@@ -2,8 +2,7 @@ package com.ita.challenges.account.domain.model;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class UserTest {
 
@@ -19,6 +18,19 @@ class UserTest {
         assertNotNull(user);
         assertEquals(userName, user.userName());
         assertEquals(userRole, user.userRole());
+    }
+
+    @Test
+    void withRole_shouldReturnNewUserWithUpdatedRole() {
+        User user = new User("ID12345", Role.GUEST);
+
+        User updatedUser = user.withRole(Role.STUDENT);
+
+        assertEquals(Role.STUDENT, updatedUser.userRole());
+        assertEquals("ID12345", updatedUser.userName());
+
+        assertNotSame(user, updatedUser);
+        assertEquals(Role.GUEST, user.userRole());
     }
 
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import com.ita.challenges.account.domain.model.Role;
 import com.ita.challenges.account.domain.model.User;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryUserRepositoryTest {
     private InMemoryUserRepository repository;
@@ -32,5 +35,19 @@ class InMemoryUserRepositoryTest {
         repository.save(new User("john", Role.GUEST));
         repository.save(new User("john", Role.MENTOR));
         assertThat(repository.storage.get("john").userRole()).isEqualTo(Role.MENTOR);
+    }
+
+    @Test
+    void save_shouldSaveAndReturnUser() {
+        User user = new User("ID12345", Role.GUEST);
+
+        User savedUser = repository.save(user);
+
+        assertNotNull(savedUser);
+        assertEquals("ID12345", savedUser.userName());
+
+        Optional<User> found = repository.findByUsername("ID12345");
+        assertTrue(found.isPresent());
+        assertEquals(Role.GUEST, found.get().userRole());
     }
 }


### PR DESCRIPTION
## Description
This PR prepares the initial setup required to implement the user creation and update endpoint.

## Changes
- `UserRepository` &  `InMemoryUserRepository`: changed the `save` method return type from `void` to `User` to support returning the saved user.
- `InMemoryUserRepositoryTest`: added test for `save` method.
- `User`: added `withRole` method to support immutable role updates.
- `UserTest`: added test for `withRole` method.
- `AccountApplication`: added the `RestClient` bean to enable communication with GitHub API.
- `GitHubUserResponse`: created a new DTO to capture the GitHub ID from the GitHub API response.ç


## Implementation details
This PR provides the foundational setup; the endpoint logic will be delivered in subsequent PRs.