### PR TITLE
feat(ticketing): integrate ticket list endpoint with repository

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -23,6 +23,10 @@ public class TicketController {
 
     @GetMapping
     public ResponseEntity<List<TicketResponse>> findAll(@AuthenticationPrincipal OAuth2User user) {
+        if (user == null || user.getAttribute("login") == null) {
+            return ResponseEntity.status(401).build();
+        }
+
         String userId = user.getAttribute("login");
 
         List<TicketResponse> tickets = ticketRepository.findAllByUserId(userId)

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -1,8 +1,11 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.ita.challenges.account.domain.port.out.TicketRepository;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -12,9 +15,27 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:4200")
 public class TicketController {
 
+    private final TicketRepository ticketRepository;
+
+    public TicketController(TicketRepository ticketRepository) {
+        this.ticketRepository = ticketRepository;
+    }
+
     @GetMapping
-    public ResponseEntity<List<TicketResponse>> findAll() {
-        return ResponseEntity.ok(List.of());
+    public ResponseEntity<List<TicketResponse>> findAll(@AuthenticationPrincipal OAuth2User user) {
+        String userId = user.getAttribute("login");
+
+        List<TicketResponse> tickets = ticketRepository.findAllByUserId(userId)
+                .stream()
+                .map(ticket -> new TicketResponse(
+                        ticket.getId(),
+                        ticket.getUserId(),
+                        ticket.getTitle(),
+                        ticket.getDescription()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(tickets);
     }
   
     @PutMapping("/{id}")

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -1,19 +1,27 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ita.challenges.account.domain.model.Ticket;
+import com.ita.challenges.account.domain.port.out.TicketRepository;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
@@ -26,13 +34,20 @@ class TicketControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private TicketRepository ticketRepository;
 
     @Test
-    @WithMockUser
-    void should_return_200_with_empty_list_when_requesting_ticket_list() throws Exception {
-        mockMvc.perform(get("/api/account/tickets"))
+    void should_return_200_with_ticket_list_when_requesting_ticket_list() throws Exception {
+        Ticket ticket = Ticket.create("testuser", "Login issue", "Unable to access my account");
+        when(ticketRepository.findAllByUserId("testuser")).thenReturn(List.of(ticket));
+
+        mockMvc.perform(get("/api/account/tickets")
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", "testuser"))))
                 .andExpect(status().isOk())
-                .andExpect(content().json("[]"));
+                .andExpect(jsonPath("$[0].userId").value("testuser"))
+                .andExpect(jsonPath("$[0].title").value("Login issue"))
+                .andExpect(jsonPath("$[0].description").value("Unable to access my account"));
     }
   
     @Test


### PR DESCRIPTION
Closes #653

## Summary
- integrate `GET /api/account/tickets` with `TicketRepository`
- obtain the current authenticated user in `TicketController`
- retrieve tickets through `findAllByUserId(...)`
- map the result to `TicketResponse`
- update the controller test accordingly

## Note
This PR completes the minimum viable integration of the already approved ticket list endpoint so it can behave as expected in the demo, without introducing a new layer or changing the current architecture.

Validation:
- `./gradlew :account-service:test --tests '*TicketControllerTest'` passed
