### PR TITLE
feat: implement ticket restore and findById repository with tests

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -25,6 +25,10 @@ public class Ticket {
         );
     }
 
+    public static Ticket restore(String id, String userId, String title, String description) {
+        return new Ticket(id, userId, title, description);
+    }
+
     public String getId() {
         return id;
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/TicketRepository.java
@@ -3,9 +3,14 @@ package com.ita.challenges.account.domain.port.out;
 import com.ita.challenges.account.domain.model.Ticket;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TicketRepository {
     List<Ticket> findAllByUserId(String userId);
 
     Ticket updateTicket(Ticket ticket);
+
+    Optional<Ticket> findById(String id);
+
+    Ticket save(Ticket newTicket);
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -24,5 +25,16 @@ public class InMemoryTicketRepository implements TicketRepository {
     @Override
     public Ticket updateTicket(Ticket ticket) {
         throw new UnsupportedOperationException("updateTicket not implemented yet");
+    }
+
+    @Override
+    public Optional<Ticket> findById(String id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public Ticket save(Ticket newTicket) {
+        storage.put(newTicket.getId(), newTicket);
+        return newTicket;
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -44,4 +44,27 @@ class InMemoryTicketRepositoryTest {
         assertEquals(ticket.getId(), found.get().getId());
         assertEquals("user-456", found.get().getUserId());
     }
+
+    @Test
+    void should_return_empty_when_ticket_id_does_not_exist() {
+        String nonExistentId = "invalid-id";
+        Optional<Ticket> found = repository.findById(nonExistentId);
+        assertTrue(found.isEmpty(), "Ticket should not be found");
+    }
+
+    @Test
+    void should_restore_ticket_correctly() {
+        String id = "123";
+        String userId = "user-1";
+        String title = "Restored Title";
+        String desc = "Restored Desc";
+
+        Ticket restored = Ticket.restore(id, userId, title, desc);
+
+        assertNotNull(restored);
+        assertEquals(id, restored.getId());
+        assertEquals(userId, restored.getUserId());
+        assertEquals(title, restored.getTitle());
+        assertEquals(desc, restored.getDescription());
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -4,10 +4,10 @@ import com.ita.challenges.account.domain.model.Ticket;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class InMemoryTicketRepositoryTest {
 
@@ -31,5 +31,17 @@ class InMemoryTicketRepositoryTest {
                         () -> repository.updateTicket(ticket));
 
         assertEquals("updateTicket not implemented yet", exception.getMessage());
+    }
+
+    @Test
+    void should_find_ticket_by_id_successfully() {
+        Ticket ticket = Ticket.create("user-456", "Test Title", "Test Desc");
+        repository.save(ticket);
+
+        Optional<Ticket> found = repository.findById(ticket.getId());
+
+        assertTrue(found.isPresent(), "Ticket existing");
+        assertEquals(ticket.getId(), found.get().getId());
+        assertEquals("user-456", found.get().getUserId());
     }
 }


### PR DESCRIPTION
Summary
Add static restore method to the Ticket entity to support secure domain object rehydration.
Define findById(String id) in the TicketRepository interface to enable individual resource lookups.
Implement findById in InMemoryTicketRepository with proper Optional handling.
Add unit tests specifically for the findById repository logic and restore factory method.

Note  
This PR focuses on establishing the core contract and domain logic required for safe updates. Please note that the save method included here is implemented strictly for testing purposes to verify the findById functionality. The official save flow implementation will remain aligned with Pedro's upcoming work.

closes #656 