### PR TITLE
Define MVP storage approach for challenge data

### DIFF
--- a/backend/challenge-service/docs/challenge-storage.md
+++ b/backend/challenge-service/docs/challenge-storage.md
@@ -1,0 +1,36 @@
+# Challenge Storage
+
+## Current situation
+
+Challenge data is currently stored only in memory, so it is lost when the
+application restarts.
+
+## MVP solution
+
+For the MVP, the project uses a lightweight, read-only JSON seed. This keeps
+initial challenge examples available between restarts without adding database
+infrastructure yet, and simplifies local testing and demos.
+
+## Options considered
+
+- In-memory only: simplest option, but every restart removes all challenges.
+- Read-only JSON seed: enough for MVP demos and local development.
+- Writable JSON: avoided because runtime writes are fragile once packaged.
+- Database: better for production, but premature for this MVP stage.
+
+## Seed data
+
+The seed file is stored in:
+
+```text
+backend/challenge-service/src/main/resources/challenges-seed.json
+```
+
+It lives in `src/main/resources` so Spring can load it from the classpath in all
+environments. It must not store runtime changes, user activity, submissions, or
+any mutable application state.
+
+## Future improvements
+
+As the project evolves, this may be replaced by a database solution better
+suited for production and advanced features.

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
@@ -1,0 +1,42 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.seed;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import java.io.InputStream;
+import java.util.List;
+
+@Component
+public class ChallengeSeedLoader implements ApplicationRunner {
+    private static final String SEED_FILE = "challenges-seed.json";
+    private final ChallengeRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public ChallengeSeedLoader(ChallengeRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        ClassPathResource resource = new ClassPathResource(SEED_FILE);
+        try (InputStream inputStream = resource.getInputStream()) {
+            List<ChallengeSeed> seeds = objectMapper.readValue(inputStream, new TypeReference<>() {});
+            seeds.stream()
+                    .map(seed -> Challenge.restore(
+                            ChallengeId.of(seed.id()),
+                            seed.title(),
+                            seed.description()
+                    ))
+                    .forEach(repository::save);
+        }
+    }
+
+    private record ChallengeSeed(String id, String title, String description) {}
+}

--- a/backend/challenge-service/src/main/resources/challenges-seed.json
+++ b/backend/challenge-service/src/main/resources/challenges-seed.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "title": "FizzBuzz",
+    "description": "Create a FizzBuzz implementation."
+  },
+  {
+    "id": "22222222-2222-2222-2222-222222222222",
+    "title": "Palindrome Checker",
+    "description": "Check if a text is palindrome."
+  },
+  {
+    "id": "33333333-3333-3333-3333-333333333333",
+    "title": "REST API Basics",
+    "description": "Build a simple CRUD REST API."
+  }
+]


### PR DESCRIPTION
## Description

This PR defines how challenge data will be handled during the MVP phase.

At this minimum viable stage, the application starts with a small set of sample challenges loaded from a read-only `JSON` file. This is a temporary measure to avoid entering data manually every time the application starts.

A small loader has been added to read that seed file when the backend starts and make those challenges available in the application.

We know that a more advanced storage solution will be needed later. For now, this keeps demos and local testing simple without introducing database infrastructure too early.

A test screenshot has also been added to show how this can look in an early demo.

<img width="471" height="264" alt="Captura de pantalla 2026-05-12 a las 22 23 35" src="https://github.com/user-attachments/assets/800a8281-43bf-47e3-bcfe-96d7ef185ed2" />

## Related Issue

Closes #592
