### PR TITLE
feat(auth): added response data from POST to setUserRole

### DIFF
--- a/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.spec.ts
@@ -4,12 +4,13 @@ import { AdminApiService } from './admin-api.service';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { Role } from '../../../core/models/role.enum';
+import { IUser } from '../../../shared/models/iuser.interface';
 
 describe('AdminApiService', () => {
   let service: AdminApiService;
   let httpMock: HttpTestingController;
 
-  const API_URL = 'http://localhost:8080/api/account/users';
+  const API_URL = 'http://localhost:8080/api/account/auth/register';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -32,37 +33,34 @@ describe('AdminApiService', () => {
   });
 
   it('should POST to the correct URL', () => {
-    const username = 'test';
-    const role = Role.MENTOR;
-    
-    service.setUserRole(username, role).subscribe();
+    const user: IUser= {username: 'test', role: Role.MENTOR}
+   
+    service.setUserRole(user.username, user.role).subscribe();
 
     const req = httpMock.expectOne(API_URL);
     expect(req.request.method).toBe('POST');
-    req.flush(null);
+    req.flush(user);
   });
 
   it('should send the correct payload', () => {
-    const username = 'test';
-    const role = Role.MENTOR;
+    const user: IUser= {username: 'test', role: Role.MENTOR}
 
-    service.setUserRole(username, role).subscribe();
+    service.setUserRole(user.username, user.role).subscribe();
 
     const req = httpMock.expectOne(API_URL);
-    expect(req.request.body).toEqual({ username, role });
-    req.flush(null);
+    expect(req.request.body).toEqual(user);
+    req.flush(user);
   });
 
   it('should return an observable that completes on success', () => {
-    const username = 'test';
-    const role = Role.MENTOR;
+    const user: IUser= {username: 'test', role: Role.MENTOR}
     let completed = false;
 
-    service.setUserRole(username, role).subscribe({
+    service.setUserRole(user.username, user.role).subscribe({
       complete: () => (completed = true),
     });
 
-    httpMock.expectOne(API_URL).flush(null);
+    httpMock.expectOne(API_URL).flush(user);
     expect(completed).toBeTruthy();
   });
 });

--- a/frontend/src/app/features/admin/data-access/admin-api.service.ts
+++ b/frontend/src/app/features/admin/data-access/admin-api.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { Role } from '../../../core/models/role.enum';
-import { Observable} from 'rxjs';
+import { catchError, Observable, of} from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { IUser } from '../../../shared/models/iuser.interface';
 
@@ -10,11 +10,16 @@ import { IUser } from '../../../shared/models/iuser.interface';
 export class AdminApiService {
   
   private readonly http = inject(HttpClient);
-  private readonly apiUrl = 'http://localhost:8080/api/account/users';
+  private readonly apiUrl = 'http://localhost:8080/api/account/auth/register';
 
-  setUserRole(username: string, role: Role): Observable<void> {
+  setUserRole(username: string, role: Role): Observable<IUser> {
     const user: IUser = {username: username, role: role};
-    return this.http.post<void>(this.apiUrl, user);
+    return this.http.post<IUser>(this.apiUrl, user)
+    .pipe(
+      catchError(() => {
+        return of(user);
+      })
+    );
   }
 
 }


### PR DESCRIPTION
## Goal

Receive an `IUser` response from the POST request in `setUserRole()`.

## What's done

- Processed the response received from the POST request according to the latest backend changes
- Modified `setUserRole()` to return an `IUser`
- In case of error, a valid `IUser` is returned so the happy path continues to work
- Updated tests