### PR TITLE
feat(challenge-detail): load challenge dynamically from route id using signal

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -1,7 +1,7 @@
-@if (challenge) {
+@if (challenge()) {
 
-  <h1>{{ challenge.title }}</h1>
-  <p>{{ challenge.description}}</p>
+  <h1>{{ challenge()?.title }}</h1>
+  <p>{{ challenge()?.description}}</p>
   <textarea
       id="challengeAnswer"
       rows="10"

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -1,38 +1,52 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChallengeDetailPage } from './challenge-detail-page';
+import { ChallengeService } from '../../services/challenge.service';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 describe('ChallengeDetailPage', () => {
   let component: ChallengeDetailPage;
   let fixture: ComponentFixture<ChallengeDetailPage>;
+  let mockChallengeService: any;
+  let mockActivatedRoute: any;
+
+  const mockChallenge = {
+    id: 'test-123',
+    title: 'Test Challenge',
+    description: 'Test Description',
+  };
 
   beforeEach(async () => {
+    mockChallengeService = { getById: vi.fn().mockReturnValue(of(mockChallenge)) };
+    mockActivatedRoute = { snapshot: { paramMap: { get: vi.fn().mockReturnValue('test-123') } } };
+
     await TestBed.configureTestingModule({
-      imports: [ChallengeDetailPage]
-    })
-    .compileComponents();
+      imports: [ChallengeDetailPage],
+      providers: [
+        { provide: ChallengeService, useValue: mockChallengeService },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChallengeDetailPage);
     component = fixture.componentInstance;
-    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render challenge data from mock', () => {
-    const mockChallenge = {
-      id: '1',
-      title: 'primer',
-      description: 'descripció 1',
-    };
-
-    component.challenge = mockChallenge;
+  it('should load challenge on init', async () => {
     fixture.detectChanges();
-    
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(mockChallenge.title);
-    expect(compiled.querySelector('p')?.textContent).toContain(mockChallenge.description);
+    await fixture.whenStable();
+    expect(component.challenge()).toEqual(mockChallenge);
+  });
+
+  it('should keep challenge undefined when not found', async () => {
+    mockChallengeService.getById.mockReturnValue(of(undefined));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component.challenge()).toBeUndefined();
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
+import { ChallengeService } from '../../services/challenge.service';
+import { ActivatedRoute } from '@angular/router';
 import { IChallenge } from '../../models/ichallenge.interface';
-import { CHALLENGES_MOCK } from '../../models/challenges.mock';
 
 @Component({
   selector: 'app-challenge-detail-page',
@@ -9,7 +10,16 @@ import { CHALLENGES_MOCK } from '../../models/challenges.mock';
   styleUrl: './challenge-detail-page.css',
 })
 export class ChallengeDetailPage {
+  private readonly challengesService = inject(ChallengeService);
+  private readonly route = inject(ActivatedRoute);
 
-  challenge: IChallenge = CHALLENGES_MOCK[0];
+  challenge = signal<IChallenge | undefined>(undefined);
 
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id')!;
+
+    this.challengesService.getById(id).subscribe((selectedChallenge) => {
+      this.challenge.set(selectedChallenge);
+    });
+  }
 }


### PR DESCRIPTION
[Task here](https://github.com/IT-Academy-BCN/ita-challenges/issues/545)
### What this PR does
Refactors `ChallengeDetailPage` to load challenge data dynamically instead of hardcoding the first mock item from `CHALLENGES_MOCK`.

### Changes

**`challenge-detail-page.ts`**
- Injects `ChallengeService` and `ActivatedRoute`
- Reads the `id` param on `ngOnInit` via `route.snapshot.paramMap.get('id')`
- Calls `challengesService.getById(id)` and stores the result in a `signal<IChallenge | undefined>`
- Removes the hardcoded `CHALLENGES_MOCK[0]` assignment

**`challenge-detail-page.html`**
- Updates `@if` block to use signal syntax: `@if (challenge())`
- Updates bindings to `challenge()?.title` and `challenge()?.description`
