### PR TITLE
fix: correct GitHub OAuth redirect URI and post-login redirect to frontend

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/api/account/login/oauth2/code/**")
                         )
-                        .defaultSuccessUrl("/api/account/profile", true)
+                        .defaultSuccessUrl("/profile", true)
                 );
         return http.build();
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .loginPage("/api/account/oauth2/authorization/github")
+                        .loginPage("/auth")
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/api/account/oauth2/authorization")
                         )

--- a/backend/account-service/src/main/resources/application.yaml
+++ b/backend/account-service/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ spring:
       client:
         registration:
           github:
+            redirect-uri: "{baseUrl}/api/account/login/oauth2/code/{registrationId}"
             client-id: ${GITHUB_CLIENT_ID}
             client-secret: ${GITHUB_CLIENT_SECRET}
             scope: user:email

--- a/docs/GitHub-Login&Callback-Setup.md
+++ b/docs/GitHub-Login&Callback-Setup.md
@@ -11,10 +11,10 @@ Defines where GitHub should send the user after they log in.
 
 ## Configuration used
 
-| Field | Value |
-|---|---|
-| App URL | `http://localhost:8080` |
-| Return URL | `http://localhost:8080/api/account/auth/github/callback` |
+| Field | Value                                                  |
+|---|--------------------------------------------------------|
+| App URL | `http://localhost:8080`                                |
+| Return URL | `http://localhost:8080/api/account/auth/github/github` |
 
 ## What success looks like
 - [ ] Clicking login sends the user to GitHub

--- a/docs/GitHub-Login&Callback-Setup.md
+++ b/docs/GitHub-Login&Callback-Setup.md
@@ -14,7 +14,7 @@ Defines where GitHub should send the user after they log in.
 | Field | Value                                                  |
 |---|--------------------------------------------------------|
 | App URL | `http://localhost:8080`                                |
-| Return URL | `http://localhost:8080/api/account/auth/github/github` |
+| Return URL | `http://localhost:8080/api/account/login/oauth2/code/github` |
 
 ## What success looks like
 - [ ] Clicking login sends the user to GitHub


### PR DESCRIPTION
Fix GitHub OAuth authentication redirect flow

Three misconfigurations were causing the GitHub OAuth flow to fail:

1. loginPage: changed from /api/account/oauth2/authorization/github to /auth. This is a browser redirect to the frontend login page, not a backend route, so it must not carry the /api/account/ prefix.
2. defaultSuccessUrl: changed from /api/account/profile to /profile. Same reasoning: after a successful login, the browser should land on the frontend profile page, which nginx routes to the frontend service. Using the /api/account/ prefix was sending the user to a non-existent backend endpoint.
3. redirect-uri in application.yaml: added explicit configuration so Spring sends http://localhost:8080/login/oauth2/code/github to GitHub as the callback URL, matching what GitHub actually redirects to after authorization.