### PR TITLE
feat(ticketing): add navigation from create ticket page to tickets

### DIFF
--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
@@ -2,25 +2,32 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateTicketPage } from './create-ticket-page';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { of } from 'rxjs';
+import { Router } from '@angular/router';
 
 describe('CreateTicketPage', () => {
   let component: CreateTicketPage;
   let fixture: ComponentFixture<CreateTicketPage>;
   let mockTicketService: Partial<TicketApiService>;
+  let mockRouter: Partial<Router>;
 
   beforeEach(async () => {
     mockTicketService = {
       create: () => of({ id:'1', userId: '', title: '', description: '' })
     };
 
+    mockRouter = {
+      navigate: vi.fn() as any
+    };
+    
     await TestBed.configureTestingModule({
       imports: [CreateTicketPage],
       providers: [
         { provide: TicketApiService, useValue: mockTicketService },
+        { provide: Router, useValue: mockRouter }        
       ]
     })
     .compileComponents();
-    
+
     fixture = TestBed.createComponent(CreateTicketPage);
     component = fixture.componentInstance;
     await fixture.whenStable();
@@ -32,5 +39,10 @@ describe('CreateTicketPage', () => {
     vi.spyOn(mockTicketService, 'create').mockReturnValue(of({ id: '1', ...testData }));
     component.onSubmit();
     expect(mockTicketService.create).toHaveBeenCalledWith(testData);
+  });
+
+  it('should navigate when call goTickets', () => {
+    component.goTickets();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/tickets']);
   });  
 });

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
@@ -13,6 +13,7 @@ import { Router } from '@angular/router';
 export class CreateTicketPage {
   readonly ticketService = inject(TicketApiService)
   readonly fb = inject(FormBuilder)
+  readonly router = inject(Router)
 
   ticketForm = this.fb.group({
     title: [''],

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { ITicketRequest } from '../../models/iticket-request.interface';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-create-ticket-page',
@@ -12,6 +13,7 @@ import { ITicketRequest } from '../../models/iticket-request.interface';
 export class CreateTicketPage {
   readonly ticketService = inject(TicketApiService)
   readonly fb = inject(FormBuilder)
+  readonly router = inject(Router)  
 
   ticketForm = this.fb.group({
     userId: [''],
@@ -23,7 +25,11 @@ export class CreateTicketPage {
     const newTicket = this.ticketForm.value as ITicketRequest
 
     this.ticketService.create(newTicket).subscribe({
-      next: () => {this.ticketForm.reset();}
+      next: () => {this.goTickets();}
     });
   }
+
+  goTickets() {
+    this.router.navigate(['/tickets']);
+  }    
 }


### PR DESCRIPTION
## Goal

When a user creates a new ticket, the page should navigate to `tickets`.

## Dependencies

- #638 

## What's Done

- Added navigation after successful ticket creation
- Added tests

## Important

Since this PR depends on #638, the changes from both PRs are shown when compared against `develop`.

The only additions in this PR are:
- the `goTickets` function
- the call to `goTickets` from `onSubmit`
- a navigation verification test
