### PR TITLE
fix(tickets): correct API endpoint and ensure userId in mock responses

### DIFF
--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.spec.ts
@@ -12,14 +12,14 @@ describe('TicketApiService', () => {
   let httpMock: HttpTestingController;
 
   const mockTicket = {
-    userId: 'u-1',
     title: 'Issue title',
     description: 'Issue description',
   };
 
-  const mockTicketResponse = { id: '1', ...mockTicket}
+  const mockTicketResponse = { id: '1', userId: 'u-1', ...mockTicket };
 
-  const API_URL = '/api/accounts/tickets';
+
+  const API_URL = '/api/account/tickets';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -104,6 +104,6 @@ describe('TicketApiService', () => {
       statusText: 'Server Error',
     });
 
-    expect(result).toEqual({ id: '1', ...mockTicket });
+    expect(result).toEqual({ id: '1', userId: 'u-1', ...mockTicket });
   });
 });

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -11,11 +11,11 @@ import {TICKETS_MOCK} from '../models/tickets.mock';
 })
 export class TicketApiService {
   private readonly http = inject(HttpClient);
-  private readonly ticketsUrl = '/api/accounts/tickets';
+  private readonly ticketsUrl = '/api/account/tickets';
 
   create(ticket: ITicketRequest): Observable<ITicket> {
     return this.http.post<ITicket>(this.ticketsUrl, ticket).pipe(
-      catchError(() => of({id: '1', ...ticket} as ITicket))
+      catchError(() => of({id: '1', userId: 'u-1', ...ticket} as ITicket))
     );
   }
 


### PR DESCRIPTION
- Change API endpoint from '/api/accounts/tickets' to '/api/account/tickets'
- Add userId to mock ticket response in error handling fallback
- Update test expectations to include userId in mock data