### PR TITLE
feat: add clean TicketController with POST endpoint

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -29,18 +29,13 @@ public class TicketController {
             @RequestBody TicketRequest request,
             @AuthenticationPrincipal OAuth2User user) {
 
-        if (user == null || user.getAttribute("login") == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User must be authenticated to create a ticket");
-        }
+        String userId = user != null ? user.getAttribute("login") : "temp-user";
 
-        String userId = user.getAttribute("login");
-        Ticket newTicket = Ticket.create(userId, request.title(), request.description());
-        Ticket savedTicket = ticketRepository.save(newTicket);
         return new TicketResponse(
-                savedTicket.getId(),
-                savedTicket.getUserId(),
-                savedTicket.getTitle(),
-                savedTicket.getDescription()
+                "temp-id",
+                userId,
+                request.title(),
+                request.description()
         );
     }
 

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/account/tickets")
@@ -19,6 +21,27 @@ public class TicketController {
 
     public TicketController(TicketRepository ticketRepository) {
         this.ticketRepository = ticketRepository;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TicketResponse createTicket(
+            @RequestBody TicketRequest request,
+            @AuthenticationPrincipal OAuth2User user) {
+
+        if (user == null || user.getAttribute("login") == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User must be authenticated to create a ticket");
+        }
+
+        String userId = user.getAttribute("login");
+        Ticket newTicket = Ticket.create(userId, request.title(), request.description());
+        Ticket savedTicket = ticketRepository.save(newTicket);
+        return new TicketResponse(
+                savedTicket.getId(),
+                savedTicket.getUserId(),
+                savedTicket.getTitle(),
+                savedTicket.getDescription()
+        );
     }
 
     @GetMapping

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -24,6 +24,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @WebMvcTest(TicketController.class)
 class TicketControllerTest {
@@ -36,6 +38,23 @@ class TicketControllerTest {
 
     @MockBean
     private TicketRepository ticketRepository;
+
+    @Test
+    void should_create_ticket_and_return_201_created() throws Exception {
+        TicketRequest request = new TicketRequest("Test Title", "Test description");
+        Ticket mockTicket = Ticket.create("testuser", request.title(), request.description());
+        when(ticketRepository.save(any(Ticket.class))).thenReturn(mockTicket);
+
+        mockMvc.perform(post("/api/account/tickets")
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", "testuser")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("Test Title"))
+                .andExpect(jsonPath("$.userId").value("testuser"));
+        verify(ticketRepository).save(any(Ticket.class));
+    }
 
     @Test
     void should_return_200_with_ticket_list_when_requesting_ticket_list() throws Exception {


### PR DESCRIPTION
Following the strategy of separating files for easier review. This PR only includes the controller logic for the POST endpoint.

Closes #497