### PR TITLE
refactor: centralize API routing with context paths

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthController.java
@@ -8,13 +8,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-
 @RestController
-@RequestMapping("/api/account")
+@RequestMapping("/auth")
 public class AuthController {
 
-    @GetMapping("/auth/me")
+    @GetMapping("/me")
     public ResponseEntity<AuthUserDto> authMe(@AuthenticationPrincipal OAuth2User user) {
         return ResponseEntity.ok(mapUser(user));
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/account/tickets")
+@RequestMapping("/tickets")
 @CrossOrigin(origins = "http://localhost:4200")
 public class TicketController {
 

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/account/users")
+@RequestMapping("/users")
 @CrossOrigin(origins = "http://localhost:4200")
 public class UserController {
 

--- a/backend/account-service/src/main/resources/application.yaml
+++ b/backend/account-service/src/main/resources/application.yaml
@@ -21,4 +21,6 @@ management:
         enabled: true
 server:
   port: ${SERVER_PORT:8080}
+  servlet:
+    context-path: /api/account
   forward-headers-strategy: framework

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -13,6 +14,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc
+@TestPropertySource(properties = "server.servlet.context-path=/api/account")
 class AuthControllerTest {
 
     @Autowired
@@ -21,6 +23,7 @@ class AuthControllerTest {
     @Test
     void authMe_whenAuthenticated_returnsUsernameAndAvatarUrl() throws Exception {
         mockMvc.perform(get("/api/account/auth/me")
+                        .contextPath("/api/account")
                         .with(oauth2Login()
                                 .attributes(attrs -> {
                                     attrs.put("login", "testuser");
@@ -33,7 +36,8 @@ class AuthControllerTest {
 
     @Test
     void authMe_whenNotAuthenticated_returnsAnonymous() throws Exception {
-        mockMvc.perform(get("/api/account/auth/me"))
+        mockMvc.perform(get("/api/account/auth/me")
+                        .contextPath("/api/account"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("anonymous"));
     }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 @WebMvcTest(AuthController.class)

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,7 +23,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TicketController.class)
 @TestPropertySource(properties = "server.servlet.context-path=/api/account")

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(TicketController.class)
+@TestPropertySource(properties = "server.servlet.context-path=/api/account")
 class TicketControllerTest {
 
     @Autowired
@@ -43,6 +45,7 @@ class TicketControllerTest {
         when(ticketRepository.findAllByUserId("testuser")).thenReturn(List.of(ticket));
 
         mockMvc.perform(get("/api/account/tickets")
+                        .contextPath("/api/account")
                         .with(oauth2Login().attributes(attrs -> attrs.put("login", "testuser"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].userId").value("testuser"))
@@ -62,6 +65,7 @@ class TicketControllerTest {
         when(ticketRepository.updateTicket(any(Ticket.class))).thenAnswer(i -> i.getArguments()[0]);
 
         mockMvc.perform(put("/api/account/tickets/{id}", ticketId)
+                        .contextPath("/api/account")
                         .with(csrf())
                         .with(oauth2Login().attributes(attrs -> attrs.put("login", currentUserId)))
                         .contentType(MediaType.APPLICATION_JSON)

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.ita.challenges.account.infrastructure.adapter.web.in;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
+@TestPropertySource(properties = "server.servlet.context-path=/api/account")
 class UserControllerTest {
 
     @Autowired
@@ -19,6 +21,7 @@ class UserControllerTest {
     @Test
     void create_shouldReturn200() throws Exception {
         mockMvc.perform(post("/api/account/users")
+                        .contextPath("/api/account")
                         .with(oauth2Login())
                         .with(csrf())
                 )

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/activity/infrastructure/adapter/in/web/controller/ActivityController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/challenges")
+@RequestMapping("/")
 public class ActivityController {
 
     private final ToggleFavoriteUseCase toggleFavoriteUseCase;

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/api/challenge")
+@RequestMapping("/")
 @CrossOrigin(origins = "http://localhost:4200")
 public class ChallengeController {
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
-@RequestMapping("/api/challenge/submissions")
+@RequestMapping("/submissions")
 public class SubmissionController {
 
     private final SaveDraftSubmissionUseCase saveDraftSubmissionUseCase;

--- a/backend/challenge-service/src/main/resources/application.yaml
+++ b/backend/challenge-service/src/main/resources/application.yaml
@@ -12,3 +12,5 @@ management:
         enabled: true
 server:
   port: ${SERVER_PORT:8080}
+  servlet:
+    context-path: /api/challenge

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -20,12 +20,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.UUID;
 
 @WebMvcTest(ChallengeController.class)
+@TestPropertySource(properties = "server.servlet.context-path=/api/challenge")
 class ChallengeControllerTest {
 
     @Autowired
@@ -46,7 +48,8 @@ class ChallengeControllerTest {
     void should_return_200_with_empty_list_when_requesting_all_challenges() throws Exception {
         when(repository.findAll()).thenReturn(List.of());
 
-        mockMvc.perform(get("/api/challenge"))
+        mockMvc.perform(get("/api/challenge/")
+                        .contextPath("/api/challenge"))
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
     }
@@ -56,7 +59,8 @@ class ChallengeControllerTest {
         Challenge saved = Challenge.create(request.title(), request.description());
         when(repository.save(any(Challenge.class))).thenReturn(saved);
 
-        mockMvc.perform(post("/api/challenge")
+        mockMvc.perform(post("/api/challenge/")
+                        .contextPath("/api/challenge")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -68,7 +72,8 @@ class ChallengeControllerTest {
     @Test  void should_return_204_when_delete_challenge_by_id() throws Exception {
         String challengeIdStr = UUID.randomUUID().toString();
 
-        mockMvc.perform(delete("/api/challenge/{id}", challengeIdStr))
+        mockMvc.perform(delete("/api/challenge/{id}", challengeIdStr)
+                        .contextPath("/api/challenge"))
                 .andExpect(status().isNoContent());
 
         verify(repository).delete(any(ChallengeId.class));
@@ -92,6 +97,7 @@ class ChallengeControllerTest {
                 .thenReturn(updatedChallenge);
 
         mockMvc.perform(put("/api/challenge/" + id)
+                        .contextPath("/api/challenge")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -113,7 +119,8 @@ class ChallengeControllerTest {
 
         when(repository.find(challengeId)).thenReturn(challenge);
 
-        mockMvc.perform(get("/api/challenge/{id}", uuid.toString()))
+        mockMvc.perform(get("/api/challenge/{id}", uuid.toString())
+                        .contextPath("/api/challenge"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(uuid.toString()))
                 .andExpect(jsonPath("$.title").value("Test Title"))

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SubmissionController.class)
+@TestPropertySource(properties = "server.servlet.context-path=/api/challenge")
 class SubmissionControllerTest {
 
     @Autowired
@@ -38,6 +40,7 @@ class SubmissionControllerTest {
         );
 
         mockMvc.perform(post("/api/challenge/submissions")
+                        .contextPath("/api/challenge")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated());


### PR DESCRIPTION
**This PR is out of the scope for the current sprint, it's just conceived as a general improvement**

What was done:
-Configured server.servlet.context-path in both application.yaml files to automatically restrict and route endpoints under their respective service prefixes (/api/account and /api/challenge).
-Adapted all controllers to the new context path.

