### PR TITLE
fix: add missing mocks in security tests

### DIFF
--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/AuthControllerTest.java
@@ -1,22 +1,29 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.ita.challenges.account.infrastructure.config.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 @WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
 @AutoConfigureMockMvc
 class AuthControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Test
     void authMe_whenAuthenticated_returnsUsernameAndAvatarUrl() throws Exception {

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -1,13 +1,16 @@
 package com.ita.challenges.account.infrastructure.config;
 
+import com.ita.challenges.account.domain.port.out.TicketRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,6 +27,12 @@ class SecurityConfigTest {
 
  @Autowired
  private SecurityFilterChain securityFilterChain;
+
+ @MockBean
+ private ClientRegistrationRepository clientRegistrationRepository;
+
+ @MockBean
+ private TicketRepository ticketRepository;
 
  @Test
  @DisplayName("Should assure the SecurityFilterChain is loaded")
@@ -51,7 +60,7 @@ class SecurityConfigTest {
  void shouldRequireAuthenticationForProtectedEndpoints() throws Exception {
   mockMvc.perform(get("/api/account/other"))
    .andExpect(status().is3xxRedirection())
-   .andExpect(redirectedUrlPattern("**/oauth2/authorization/github"));
+   .andExpect(redirectedUrlPattern("**/auth"));
  }
 
 }


### PR DESCRIPTION
**URGENT FIX** 

-Add @MockBean for ClientRegistrationRepository and TicketRepository in SecurityConfigTest to satisfy bean dependencies in @WebMvcTest context.
-Add @Import(SecurityConfig.class) and @MockBean ClientRegistrationRepository in AuthControllerTest so the custom permit rules apply when testing unauthenticated requests.
-Update redirect assertion in SecurityConfigTest to match the configured login page (/auth).