### PR TITLE
feat: implement create ticket logic and persistence

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -42,33 +42,6 @@ public class TicketController {
         return ResponseEntity.ok(tickets);
     }
 
-    @PostMapping
-    public ResponseEntity<TicketResponse> create(
-            @RequestBody TicketRequest ticketRequest,
-            @AuthenticationPrincipal OAuth2User user) {
-
-        if (user == null || user.getAttribute("login") == null) {
-            return ResponseEntity.status(401).build();
-        }
-
-        String currentUserId = user.getAttribute("login");
-        Ticket newTicket = Ticket.create(
-                currentUserId,
-                ticketRequest.title(),
-                ticketRequest.description()
-        );
-
-        Ticket savedTicket = ticketRepository.save(newTicket);
-        TicketResponse response = new TicketResponse(
-                savedTicket.getId(),
-                savedTicket.getUserId(),
-                savedTicket.getTitle(),
-                savedTicket.getDescription()
-        );
-
-        return ResponseEntity.status(201).body(response);
-    }
-
     @PutMapping("/{id}")
     public ResponseEntity<TicketResponse> update(
             @PathVariable String id,

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -42,6 +42,33 @@ public class TicketController {
         return ResponseEntity.ok(tickets);
     }
 
+    @PostMapping
+    public ResponseEntity<TicketResponse> create(
+            @RequestBody TicketRequest ticketRequest,
+            @AuthenticationPrincipal OAuth2User user) {
+
+        if (user == null || user.getAttribute("login") == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String currentUserId = user.getAttribute("login");
+        Ticket newTicket = Ticket.create(
+                currentUserId,
+                ticketRequest.title(),
+                ticketRequest.description()
+        );
+
+        Ticket savedTicket = ticketRepository.save(newTicket);
+        TicketResponse response = new TicketResponse(
+                savedTicket.getId(),
+                savedTicket.getUserId(),
+                savedTicket.getTitle(),
+                savedTicket.getDescription()
+        );
+
+        return ResponseEntity.status(201).body(response);
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<TicketResponse> update(
             @PathVariable String id,

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -22,6 +22,20 @@ class InMemoryTicketRepositoryTest {
     }
 
     @Test
+    void should_save_ticket_successfully() {
+        Ticket newTicket = Ticket.create("user-999", "New Ticket", "Probe Description");
+
+        Ticket savedTicket = repository.save(newTicket);
+
+        assertNotNull(savedTicket);
+        assertEquals(newTicket.getId(), savedTicket.getId());
+        assertEquals("user-999", savedTicket.getUserId());
+
+        Optional<Ticket> found = repository.findById(savedTicket.getId());
+        assertTrue(found.isPresent());
+    }
+
+    @Test
     void should_update_ticket_data_successfully() {
         Ticket original = Ticket.create("user-1", "Old Title", "Old Desc");
         repository.save(original);


### PR DESCRIPTION
Closes #498

### What does this PR include?
This PR implements the creation logic and in-memory persistence for tickets, connecting the controller with the repository as defined in the current sprint scope.

**Key changes:**
- Added the `@PostMapping` method in `TicketController` to handle ticket creation, delegating persistence to the adapter.
- Verified that the `save()` implementation in `InMemoryTicketRepository` correctly stores data in the concurrent map.
- Added the `should_save_ticket_successfully` unit test in `InMemoryTicketRepositoryTest` to ensure coverage for the creation flow.

*(Note: Following the current architecture of the `develop` branch, persistence remains in-memory and no real database is introduced at this stage).*