### PR TITLE
feat: implement create ticket use case and unit tests

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/application/service/CreateTicketService.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/application/service/CreateTicketService.java
@@ -1,0 +1,22 @@
+package com.ita.challenges.account.application.service;
+
+import com.ita.challenges.account.domain.model.Ticket;
+import com.ita.challenges.account.domain.port.in.CreateTicketUseCase;
+import com.ita.challenges.account.domain.port.out.TicketRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateTicketService implements CreateTicketUseCase {
+
+    private final TicketRepository ticketRepository;
+
+    public CreateTicketService(TicketRepository ticketRepository) {
+        this.ticketRepository = ticketRepository;
+    }
+
+    @Override
+    public Ticket createTicket(String userId, String title, String description) {
+        Ticket newTicket = Ticket.create(userId, title, description);
+        return ticketRepository.save(newTicket);
+    }
+}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/in/CreateTicketUseCase.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/in/CreateTicketUseCase.java
@@ -1,0 +1,7 @@
+package com.ita.challenges.account.domain.port.in;
+
+import com.ita.challenges.account.domain.model.Ticket;
+
+public interface CreateTicketUseCase {
+    Ticket createTicket(String userId, String title, String description);
+}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/application/service/CreateTicketServiceTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/application/service/CreateTicketServiceTest.java
@@ -1,0 +1,44 @@
+package com.ita.challenges.account.application.service;
+
+import com.ita.challenges.account.domain.model.Ticket;
+import com.ita.challenges.account.domain.port.out.TicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateTicketServiceTest {
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @InjectMocks
+    private CreateTicketService createTicketService;
+
+    @Test
+    void should_create_and_save_ticket_successfully() {
+        String userId = "user-123";
+        String title = "Fix login issue";
+        String description = "The login button is not responding on mobile devices.";
+
+        Ticket mockSavedTicket = Ticket.restore("ticket-999", userId, title, description);
+
+        when(ticketRepository.save(any(Ticket.class))).thenReturn(mockSavedTicket);
+
+        Ticket result = createTicketService.createTicket(userId, title, description);
+
+        assertNotNull(result);
+        assertEquals("ticket-999", result.getId());
+        assertEquals(userId, result.getUserId());
+        assertEquals(title, result.getTitle());
+        assertEquals(description, result.getDescription());
+
+        verify(ticketRepository, times(1)).save(any(Ticket.class));
+    }
+}


### PR DESCRIPTION
This PR implements the CreateTicketUseCase to decouple domain logic from the controller, as requested during the review of PR #689