### PR TITLE
fix(submission): update submission status enum to correct progress states

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/valueobject/SubmissionStatus.java
@@ -1,5 +1,9 @@
 package com.itachallenges.challengeservice.submission.domain.valueobject;
 
 public enum SubmissionStatus {
-    IN_PROGRESS, FINAL, INCOMPLETE
+    NOT_STARTED,
+    IN_PROGRESS,
+    SUBMITTED,
+    APPROVED,
+    FAILED_REVIEW
 }


### PR DESCRIPTION
Because of a merging issues we are experiencing problems, and the best choice is creating a new branch and a new PR to allow the  task to meet the deadline.

    NOT_STARTED,
    IN_PROGRESS,
    SUBMITTED,
    APPROVED,
    FAILED_REVIEW

Replaces outdated IN_PROGRESS, FINAL, and INCOMPLETE status values with NOT_STARTED, IN_PROGRESS, SUBMITTED, APPROVED, and FAILED_REVIEW to accurately track submission progress through the challenge workflow.

BREAKING CHANGE: FINAL and INCOMPLETE enum values have been removed from SubmissionStatus. Any code referencing these deprecated values must be updated to use the new status set.