### PR TITLE
Fix/580 challenge allow create an answer in progress

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -4,48 +4,39 @@ import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId
 import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionStatus;
+import lombok.Getter;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
+
 
 public class Submission {
 
+    @Getter
     private SubmissionId id;
+    @Getter
     private ChallengeId challengeId;
+    @Getter
     private UserId userId;
+    @Getter
     private SubmissionStatus status;
+    @Getter
     private String code;
     private Instant createdAt;
     private Instant updatedAt;
 
-    private final List<Object> domainEvents = new ArrayList<>();
 
     private Submission() {}
 
     public static Submission createInProgress(SubmissionId id, ChallengeId challengeId, UserId userId, String code) {
-        // TODO: create and return a new Submission with IN_PROGRESS status
-        return null;
+        Submission submission = new Submission();
+        submission.id = id;
+        submission.challengeId = challengeId;
+        submission.userId = userId;
+        submission.code = code;
+        submission.status = SubmissionStatus.IN_PROGRESS;
+        submission.createdAt = Instant.now();
+        submission.updatedAt = Instant.now();
+        return submission;
     }
 
-    public void finalize(String code) {
-        // TODO: transition status to FINAL and emit SubmissionFinished event
-        // TODO: guard against invalid transitions
-    }
-
-    public void markIncomplete() {
-        // TODO: transition status to INCOMPLETE and emit SubmissionMarkedIncomplete event
-        // TODO: guard against invalid transitions
-    }
-
-    public List<Object> pullDomainEvents() {
-        // TODO: return accumulated domain events and clear the list
-        return null;
-    }
-
-    public SubmissionId getId() { return id; }
-    public ChallengeId getChallengeId() { return challengeId; }
-    public UserId getUserId() { return userId; }
-    public SubmissionStatus getStatus() { return status; }
-    public String getCode() { return code; }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -8,22 +8,16 @@ import lombok.Getter;
 
 import java.time.Instant;
 
-
+@Getter
 public class Submission {
 
-    @Getter
     private SubmissionId id;
-    @Getter
     private ChallengeId challengeId;
-    @Getter
     private UserId userId;
-    @Getter
     private SubmissionStatus status;
-    @Getter
     private String code;
     private Instant createdAt;
     private Instant updatedAt;
-
 
     private Submission() {}
 

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/domain/SubmissionTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/domain/SubmissionTest.java
@@ -1,0 +1,37 @@
+package com.itachallenges.challengeservice.submission.domain;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class SubmissionTest {
+
+    private static final UUID CHALLENGE_UUID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final UUID USER_UUID      = UUID.fromString("660e8400-e29b-41d4-a716-446655440001");
+
+    @Test
+    void should_create_submission_in_progress_with_all_fields_populated() {
+        SubmissionId   submissionId = SubmissionId.generate();
+        ChallengeId   challengeId  = new ChallengeId(CHALLENGE_UUID);
+        UserId        userId       = new UserId(USER_UUID);
+        String        code         = "System.out.println(\"Hello this is a submission in progress\");";
+
+        Submission submission = Submission.createInProgress(submissionId, challengeId, userId, code);
+
+        assertThat(submission.getId()).isEqualTo(submissionId);
+        assertThat(submission.getChallengeId()).isEqualTo(challengeId);
+        assertThat(submission.getUserId()).isEqualTo(userId);
+        assertThat(submission.getCode()).isEqualTo(code);
+        assertThat(submission.getStatus()).isEqualTo(SubmissionStatus.IN_PROGRESS);
+        assertThat(submission.getCreatedAt()).isNotNull();
+        assertThat(submission.getUpdatedAt()).isNotNull();
+    }
+
+}


### PR DESCRIPTION
Allow the users to create an answer to a challenge in "IN PROGRESS" by default.
There are some methods erased in this PR for the better understanding of the class and to allow the future developers to implement whatever they think is appropriate.