### PR TITLE
Fix/security config nginx

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/account/tickets")
-@CrossOrigin(origins = "http://localhost:4200")
 public class TicketController {
 
     private final TicketRepository ticketRepository;

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,11 +1,9 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/account/users")
-@CrossOrigin(origins = "http://localhost:4200")
 public class UserController {
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -13,7 +13,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/account/auth/register"))
+                .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/account/auth/**").permitAll()
                         .requestMatchers("/api/account/oauth2/**").permitAll()

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -16,7 +16,6 @@ import java.util.List;
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/challenge")
-@CrossOrigin(origins = "http://localhost:4200")
 public class ChallengeController {
 
     private final ChallengeRepository repository;

--- a/infra/gateway/nginx.conf
+++ b/infra/gateway/nginx.conf
@@ -1,47 +1,70 @@
+map $http_origin $cors_origin {
+    default "";
+    "http://localhost:4200"      $http_origin;
+    "https://ita-challenges.com" $http_origin;
+}
+
 server {
-  listen 80;
-  server_name _;
+    listen 80;
+    server_name _;
 
-  # ACCOUNT
-  location /api/account/ {
-    proxy_pass http://account-service:8080;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Host $http_host;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+    # ACCOUNT
+    location /api/account/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $cors_origin;
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS";
+            add_header Access-Control-Allow-Headers "Authorization, Content-Type";
+            add_header Access-Control-Allow-Credentials "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin $cors_origin;
+        add_header Access-Control-Allow-Credentials "true";
 
-  # USERS
-  location /itachallenge/api/v1/users {
-    proxy_pass http://account-service:8080/api/v1/users;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+        proxy_pass http://account-service:8080;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
-  # CHALLENGES
-  location /itachallenge/api/v1/challenges {
-    proxy_pass http://challenge-service:8080/api/v1/challenges;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+    # CHALLENGE
+    location /api/challenge/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $cors_origin;
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS";
+            add_header Access-Control-Allow-Headers "Authorization, Content-Type";
+            add_header Access-Control-Allow-Credentials "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin $cors_origin;
+        add_header Access-Control-Allow-Credentials "true";
 
-  # ACTUATORS
-  location /actuator/users/ {
-    proxy_pass http://account-service:8080/actuator/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+        proxy_pass http://challenge-service:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
-  location /actuator/challenges/ {
-    proxy_pass http://challenge-service:8080/actuator/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+    # ACTUATORS
+    location /actuator/users/ {
+        proxy_pass http://account-service:8080/actuator/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
-  # FRONTEND
-  location / {
-    proxy_pass http://frontend:80;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  }
+    location /actuator/challenges/ {
+        proxy_pass http://challenge-service:8080/actuator/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # FRONTEND
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }

--- a/infra/gateway/nginx.conf
+++ b/infra/gateway/nginx.conf
@@ -29,7 +29,7 @@ server {
     }
 
     # CHALLENGE
-    location /api/challenge/ {
+    location /api/challenge {
         if ($request_method = OPTIONS) {
             add_header Access-Control-Allow-Origin $cors_origin;
             add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS";


### PR DESCRIPTION
Fix CORS configuration by centralizing it in Nginx gateway

Remove @CrossOrigin annotations from service controllers and configure CORS at the Nginx gateway level. This ensures a single entry point handles cross-origin requests, avoids duplicated configuration across services, and aligns with the existing network security model where only the gateway is publicly exposed.