### PR TITLE
fix(submission): add @Repository to InMemorySubmissionRepository for  draft support

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -1,16 +1,33 @@
 package com.itachallenges.challengeservice.submission.application.usecase;
 
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
-    // TODO: inject SubmissionRepository
+
+    private final SubmissionRepository repository;
+
+    public SaveDraftSubmissionUseCaseHandler(SubmissionRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void execute(SaveDraftSubmissionCommand command) {
-        // TODO: create or update submission with IN_PROGRESS status
-        // TODO: save submission
+
+        Submission submission = Submission.createInProgress(
+                SubmissionId.generate(),
+                ChallengeId.of(command.challengeId()),
+                UserId.of(command.userId()),
+                command.code()
+        );
+
+        repository.save(submission);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/persistence/InMemorySubmissionRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/persistence/InMemorySubmissionRepository.java
@@ -5,11 +5,13 @@ import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import org.springframework.stereotype.Repository;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Repository
 public class InMemorySubmissionRepository implements SubmissionRepository {
 
     private final Map<SubmissionId, Submission> storage = new ConcurrentHashMap<>();

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -51,4 +51,29 @@ class SubmissionControllerTest {
         assertThat(captor.getValue().userId()).isEqualTo("student-1");
         assertThat(captor.getValue().code()).isEmpty();
     }
+
+    @Test
+    void shouldSaveDraftWithCodeWhenCodeIsProvided() throws Exception {
+
+        SaveDraftSubmissionRequest request = new SaveDraftSubmissionRequest(
+                "challenge-1",
+                "student-1",
+                "console.log('hello world in a happy path')"
+        );
+
+        mockMvc.perform(post("/api/challenge/submissions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        ArgumentCaptor<SaveDraftSubmissionCommand> captor =
+                ArgumentCaptor.forClass(SaveDraftSubmissionCommand.class);
+
+        verify(saveDraftSubmissionUseCase).execute(captor.capture());
+
+        assertThat(captor.getValue().challengeId()).isEqualTo("challenge-1");
+        assertThat(captor.getValue().userId()).isEqualTo("student-1");
+        assertThat(captor.getValue().code()).isEqualTo("console.log('hello world in a happy path')");
+    }
+
 }


### PR DESCRIPTION
- **SaveDraftSubmissionUseCaseHandler**: Implements the use case handler that persists draft submissions with `IN_PROGRESS` status
- **SubmissionControllerTest**: Adds unit tests covering the draft submission flow, including saving submissions with code content
- **InMemorySubmissionRepository**: Adds `@Repository` annotation to ensure proper Spring bean registration and component scanning