### PR TITLE
feat(challenge): add ExistsFinalSubmissionResponse and initial placeholder endpoint

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -31,7 +31,7 @@ public class SubmissionController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping
+    @GetMapping("/exists-final-submission")
     public ResponseEntity<ExistsFinalSubmissionResponse> existsFinalSubmission(
             @RequestParam String userId,
             @RequestParam String challengeId

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -31,7 +31,7 @@ public class SubmissionController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/exists-final-submission")
+    @GetMapping("/finalized")
     public ResponseEntity<ExistsFinalSubmissionResponse> existsFinalSubmission(
             @RequestParam String userId,
             @RequestParam String challengeId

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.
 
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
+import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.ExistsFinalSubmissionResponse;
 import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.SaveDraftSubmissionRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class SubmissionController {
 
     private final SaveDraftSubmissionUseCase saveDraftSubmissionUseCase;
+
     public SubmissionController(SaveDraftSubmissionUseCase saveDraftSubmissionUseCase) {
         this.saveDraftSubmissionUseCase = saveDraftSubmissionUseCase;
     }
@@ -27,5 +29,13 @@ public class SubmissionController {
                 code
         ));
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<ExistsFinalSubmissionResponse> existsFinalSubmission(
+            @RequestParam String userId,
+            @RequestParam String challengeId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(new ExistsFinalSubmissionResponse(false));
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/ExistsFinalSubmissionResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/ExistsFinalSubmissionResponse.java
@@ -1,0 +1,6 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
+
+public record ExistsFinalSubmissionResponse(
+        boolean exists
+) {
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SubmissionController.class)
@@ -92,6 +93,15 @@ class SubmissionControllerTest {
         assertThat(captor.getValue().challengeId()).isEqualTo("challenge-1");
         assertThat(captor.getValue().userId()).isEqualTo("student-1");
         assertThat(captor.getValue().code()).isEqualTo("console.log('hello world in a happy path')");
+    }
+
+    @Test
+    void existsFinalSubmission_ShouldReturnOkWithFalseStatus() throws Exception {
+        mockMvc.perform(get("/api/challenge/submissions/exists-final-submission")
+                        .param("userId", "1")
+                        .param("challengeId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exists").value(false));
     }
 
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -97,7 +97,7 @@ class SubmissionControllerTest {
 
     @Test
     void existsFinalSubmission_ShouldReturnOkWithFalseStatus() throws Exception {
-        mockMvc.perform(get("/api/challenge/submissions/exists-final-submission")
+        mockMvc.perform(get("/api/challenge/submissions/finalized")
                         .param("userId", "1")
                         .param("challengeId", "1"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Description
Created the `ExistsFinalSubmissionResponse` DTO and the initial placeholder endpoint to check if a user has completed a challenge. Endpoint logic to be implemented.

## Changes
- `ExistsFinalSubmissionResponse`: defined the Response DTO with the `exists` boolean field.
- `SubmissionController`: created the initial `existsFinalSubmission` GET endpoint placeholder returning a default `200 OK` with `exists: false`.
- `SubmissionControllerTest`: added a smoke test (`existsFinalSubmission_ShouldReturnOkWithFalseStatus`) to validate the endpoint's contract and response structure.

## Implementation details
This PR only establishes the API contract (endpoint skeleton and DTO format). The actual connection to the repository will be delivered in a subsequent PR.