### PR TITLE
feat(challenges): extend challenge interfaces with solution, language and difficulty (#737)

### DIFF
--- a/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
@@ -1,1 +1,1 @@
-export type ChallengeDifficulty = 'easy' | 'medium' | 'hard';
+export type ChallengeDifficulty = 'EASY' | 'MEDIUM' | 'HARD';

--- a/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
@@ -1,0 +1,1 @@
+export type ChallengeDifficulty = 1 | 2 | 3;

--- a/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
@@ -1,1 +1,1 @@
-export type ChallengeDifficulty = 1 | 2 | 3;
+export type ChallengeDifficulty = 'easy' | 'medium' | 'hard';

--- a/frontend/src/app/features/challenges/models/challenge-language.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-language.type.ts
@@ -1,1 +1,1 @@
-export type ChallengeLanguage = 'java' | 'php' | 'javascript' | 'typescript' | 'python' | 'sql';
+export type ChallengeLanguage = 'JAVA' | 'PHP' | 'JAVASCRIPT' | 'TYPESCRIPT' | 'PYTHON' | 'SQL';

--- a/frontend/src/app/features/challenges/models/challenge-language.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-language.type.ts
@@ -1,0 +1,1 @@
+export type ChallengeLanguage = 'java' | 'php' | 'javascript' | 'typescript' | 'python' | 'sql';

--- a/frontend/src/app/features/challenges/models/challenges.mock.ts
+++ b/frontend/src/app/features/challenges/models/challenges.mock.ts
@@ -2,18 +2,27 @@ import { IChallenge } from './ichallenge.interface';
 
 export const CHALLENGES_MOCK: IChallenge[] = [
   {
-    id: "1",
-    title: "primer",
-    description: "descripció 1"
+    id: '1',
+    title: 'primer',
+    description: 'descripció 1',
+    solution: 'solució 1',
+    language: 'TYPESCRIPT',
+    difficulty: 'EASY',
   },
   {
-    id: "2",
-    title: "segon",
-    description: "descripció 2"
+    id: '2',
+    title: 'segon',
+    description: 'descripció 2',
+    solution: 'solució 2',
+    language: 'JAVA',
+    difficulty: 'MEDIUM',
   },
   {
-    id: "3",
-    title: "tercer",
-    description: "descripció 3"
+    id: '3',
+    title: 'tercer',
+    description: 'descripció 3',
+    solution: 'solució 3',
+    language: 'SQL',
+    difficulty: 'HARD',
   },
 ];

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -1,6 +1,5 @@
-import { ChallengeDifficulty } from "./challenge-difficulty.type";
 import { ChallengeLanguage } from "./challenge-language.type";
-
+import { ChallengeDifficulty } from "./challenge-difficulty.type";
 
 export interface IChallengeRequest {
     title: string;

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -1,4 +1,11 @@
+import { ChallengeDifficulty } from "./challenge-difficulty.type";
+import { ChallengeLanguage } from "./challenge-language.type";
+
+
 export interface IChallengeRequest {
-    title: string, 
-	description: string,
+  title: string;
+  description: string;
+  solution?: string;
+  language?: ChallengeLanguage;
+  difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -3,9 +3,9 @@ import { ChallengeLanguage } from "./challenge-language.type";
 
 
 export interface IChallengeRequest {
-  title: string;
-  description: string;
-  solution?: string;
-  language?: ChallengeLanguage;
-  difficulty?: ChallengeDifficulty;
+    title: string;
+    description: string;
+    solution?: string;
+    language?: ChallengeLanguage;
+    difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -2,10 +2,10 @@ import { ChallengeLanguage } from './challenge-language.type';
 import { ChallengeDifficulty } from './challenge-difficulty.type';
 
 export interface IChallenge {
-  id: string;
-  title: string;
-  description: string;
-  solution?: string;
-  language?: ChallengeLanguage;
-  difficulty?: ChallengeDifficulty;
+    id: string;
+    title: string;
+    description: string;
+    solution?: string;
+    language?: ChallengeLanguage;
+    difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,6 +1,5 @@
 import { ChallengeLanguage } from './challenge-language.type';
 import { ChallengeDifficulty } from './challenge-difficulty.type';
-
 export interface IChallenge {
     id: string;
     title: string;

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,5 +1,11 @@
+import { ChallengeLanguage } from './challenge-language.type';
+import { ChallengeDifficulty } from './challenge-difficulty.type';
+
 export interface IChallenge {
-    id: string, 
-    title: string, 
-	description: string,
+  id: string;
+  title: string;
+  description: string;
+  solution?: string;
+  language?: ChallengeLanguage;
+  difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,5 +1,6 @@
 import { ChallengeLanguage } from './challenge-language.type';
 import { ChallengeDifficulty } from './challenge-difficulty.type';
+
 export interface IChallenge {
     id: string;
     title: string;


### PR DESCRIPTION
### [Task Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/737)

## Summary
Introduced new challenge domain types and updated core data models to support solution, language and difficulty metadata, preparing the system for upcoming form and API enhancements without breaking existing functionality.

This change extends the current challenge structure in a backward-compatible way by introducing optional fields as an intermediate migration step.

---

## What's included
- Added `ChallengeLanguage` union type with supported values:
  - `java`, `php`, `javascript`, `typescript`, `python`, `sql`
- Added `ChallengeDifficulty` union type:
  - `easy` | `medium` | `hard`
- Extended `IChallengeRequest` interface with new optional fields:
  - `solution?`
  - `language?`
  - `difficulty?`
- Extended `IChallenge` interface to reflect the full domain model consistently
- Updated type imports across model definitions
- Ensured existing mocks remain compatible with previous structure
- Updated challenge mocks to include the new optional fields (solution, language, difficulty) and align them with the updated IChallenge interface.

---

## Notes
- This PR is intentionally non-breaking and focuses only on data model evolution.
- UI and service layer integration will be handled in subsequent PRs.
- Once migration is complete, optional fields may be promoted to required based on backend constraints.