### PR TITLE
"feat: add ChallengeDifficulty enum (closes #720)"

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDifficulty.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeDifficulty.java
@@ -1,0 +1,7 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+
+public enum ChallengeDifficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}


### PR DESCRIPTION
## Description
This PR introduces the `ChallengeDifficulty` enum within the domain layer, defining the allowed difficulty levels for any coding challenge in the system.

## Context
Following up on the domain foundation for epic **#710** (*Create a challenge*), this is the second atomic PR aimed at setting up the necessary value objects. Creating these enums independently prevents merge conflicts and keeps the core domain isolated.

## Changes Introduced
* Created the `ChallengeDifficulty` value object at `catalog/domain/valueobject/`.
* Added the standard difficulty levels: `EASY`, `MEDIUM`, and `HARD`.

## Impact and Next Steps
Together with the `ChallengeLanguage` enum, this fully unblocks the Backend team to proceed with:
* **#772** (Update the domain Challenge object)
* **#722** (Update the Challenge input and output data structures)

Closes #720