### PR TITLE
feat: Configure logout endpoint to invalidate session and delete cookie.

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .logout(logout -> logout
                 .logoutUrl("/api/account/auth/logout")
                 .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID")
+                .deleteCookies("JSESSIONID", "remember-me")
                 .logoutSuccessHandler((request, response, authentication) ->
                         response.setStatus(200))
                 );

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -29,6 +29,13 @@ public class SecurityConfig {
                                 .baseUri("/api/account/login/oauth2/code/**")
                         )
                         .defaultSuccessUrl("/profile", true)
+                )
+                .logout(logout -> logout
+                .logoutUrl("/api/account/auth/logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessHandler((request, response, authentication) ->
+                        response.setStatus(200))
                 );
         return http.build();
     }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -26,22 +26,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SecurityConfigTest {
 
 @Autowired
-    private MockMvc mockMvc;
+private MockMvc mockMvc;
 
 @Autowired
-    private SecurityFilterChain securityFilterChain;
+private SecurityFilterChain securityFilterChain;
 
 @MockBean
-    private ClientRegistrationRepository clientRegistrationRepository;
+private ClientRegistrationRepository clientRegistrationRepository;
 
 @MockBean
-    private TicketRepository ticketRepository;
+private TicketRepository ticketRepository;
 
 @MockBean
-    private UserRepository userRepository;
+private UserRepository userRepository;
 
 @MockBean
-    private RestClient restClient;
+private RestClient restClient;
 
     @Test
     @DisplayName("Should assure the SecurityFilterChain is loaded")

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package com.ita.challenges.account.infrastructure.config;
 
 import com.ita.challenges.account.domain.port.out.TicketRepository;
+import com.ita.challenges.account.domain.port.out.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,8 +14,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestClient;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,45 +25,60 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(SecurityConfig.class)
 class SecurityConfigTest {
 
- @Autowired
- private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
- @Autowired
- private SecurityFilterChain securityFilterChain;
+    @Autowired
+    private SecurityFilterChain securityFilterChain;
 
- @MockBean
- private ClientRegistrationRepository clientRegistrationRepository;
+    @MockBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
- @MockBean
- private TicketRepository ticketRepository;
+    @MockBean
+    private TicketRepository ticketRepository;
 
- @Test
- @DisplayName("Should assure the SecurityFilterChain is loaded")
- void contextLoads() {
-  assertThat(securityFilterChain).isNotNull();
- }
+    @MockBean
+    private UserRepository userRepository;
 
- @ParameterizedTest
- @ValueSource(strings = {
-  "/api/account/auth/me",
-  "/api/account/oauth2/authorization/github",
-  "/api/account/login/oauth2"
- })
- @DisplayName("Should permit all requests to public endpoints")
- void shouldPermitAllRequestsToPublicEndpoints(String path) throws Exception {
-  mockMvc.perform(get(path))
-   .andExpect(result -> {
-    int status = result.getResponse().getStatus();
-    org.junit.jupiter.api.Assertions.assertNotEquals(HttpStatus.FORBIDDEN.value(), status);
-   });
- }
+    @MockBean
+    private RestClient restClient;
 
- @Test
- @DisplayName("Should require authentication for protected endpoints and redirect to OAuth2")
- void shouldRequireAuthenticationForProtectedEndpoints() throws Exception {
-  mockMvc.perform(get("/api/account/other"))
-   .andExpect(status().is3xxRedirection())
-   .andExpect(redirectedUrlPattern("**/auth"));
- }
+    @Test
+    @DisplayName("Should assure the SecurityFilterChain is loaded")
+    void contextLoads() {
+        assertThat(securityFilterChain).isNotNull();
+    }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/account/auth/me",
+            "/api/account/oauth2/authorization/github",
+            "/api/account/login/oauth2"
+    })
+    @DisplayName("Should permit all requests to public endpoints")
+    void shouldPermitAllRequestsToPublicEndpoints(String path) throws Exception {
+        mockMvc.perform(get(path))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    org.junit.jupiter.api.Assertions.assertNotEquals(HttpStatus.FORBIDDEN.value(), status);
+                });
+    }
+
+    @Test
+    @DisplayName("Should require authentication for protected endpoints and redirect to OAuth2")
+    void shouldRequireAuthenticationForProtectedEndpoints() throws Exception {
+        mockMvc.perform(get("/api/account/other"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/auth"));
+    }
+
+    @Test
+    @DisplayName("Should permit POST requests to logout endpoint")
+    void shouldPermitLogoutEndpoint() throws Exception {
+        mockMvc.perform(post("/api/account/auth/logout"))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    org.junit.jupiter.api.Assertions.assertNotEquals(HttpStatus.FORBIDDEN.value(), status);
+                });
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -25,22 +25,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(SecurityConfig.class)
 class SecurityConfigTest {
 
-    @Autowired
+@Autowired
     private MockMvc mockMvc;
 
-    @Autowired
+@Autowired
     private SecurityFilterChain securityFilterChain;
 
-    @MockBean
+@MockBean
     private ClientRegistrationRepository clientRegistrationRepository;
 
-    @MockBean
+@MockBean
     private TicketRepository ticketRepository;
 
-    @MockBean
+@MockBean
     private UserRepository userRepository;
 
-    @MockBean
+@MockBean
     private RestClient restClient;
 
     @Test

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -76,9 +76,7 @@ class SecurityConfigTest {
     @DisplayName("Should permit POST requests to logout endpoint")
     void shouldPermitLogoutEndpoint() throws Exception {
         mockMvc.perform(post("/api/account/auth/logout"))
-                .andExpect(result -> {
-                    int status = result.getResponse().getStatus();
-                    org.junit.jupiter.api.Assertions.assertNotEquals(HttpStatus.FORBIDDEN.value(), status);
-                });
+                .andExpect(status().isOk());
     }
 }
+


### PR DESCRIPTION
Currently, when a user logs out and refreshes the page, 
the session is automatically restored due to the JSESSIONID cookie.

Changes:
- Added logout configuration in SecurityConfig with endpoint POST /api/account/auth/logout
- Invalidate HTTP session on logout
- Delete JSESSIONID cookie on logout
- Added logout endpoint to permitted URLs
- Updated SecurityConfigTest with missing mocks

Expected behavior:
After logout, refreshing the page keeps the user logged out.

Closes #766 