### PR TITLE
feat(Ticketing): implement addComment and setStatus with unit tests

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -54,38 +54,22 @@ public class Ticket {
         );
     }
 
-    public static Ticket restore(
-            String id, String userId, String title, String description,
+    public static Ticket restore(String id, String userId, String title, String description,
             TicketStatus status, String comment, Instant createdAt, Instant updatedAt) {
         return new Ticket(id, userId, title, description, status, comment, createdAt, updatedAt);
     }
-
-    public Ticket withComment(String comment) {
-        return new Ticket(
-                this.id,
-                this.userId,
-                this.title,
-                this.description,
-                this.status,
-                comment,
-                this.createdAt,
-                Instant.now()
-        );
+    public Ticket withUpdates(TicketStatus status, String comment) {
+    return new Ticket(
+            this.id,
+            this.userId,
+            this.title,
+            this.description,
+            status != null ? status : this.status,
+            comment != null ? comment : this.comment,
+            this.createdAt,
+            Instant.now()
+    );
     }
-
-    public Ticket withStatus(TicketStatus status) {
-        return new Ticket(
-                this.id,
-                this.userId,
-                this.title,
-                this.description,
-                status,
-                this.comment,
-                this.createdAt,
-                Instant.now()
-        );
-    }
-
     public String getId() {
         return id;
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -29,9 +29,9 @@ public class Ticket {
         return new Ticket(id, userId, title, description);
     }
 
-    public Ticket addComment(String comment) {
-    return this;
-}
+     public Ticket addComment(String comment) {
+        throw new UnsupportedOperationException("addComment is not implemented yet.");
+    }
 
     public String getId() {
         return id;

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -29,6 +29,10 @@ public class Ticket {
         return new Ticket(id, userId, title, description);
     }
 
+    public Ticket addComment(String comment) {
+    return this;
+}
+
     public String getId() {
         return id;
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -1,5 +1,6 @@
 package com.ita.challenges.account.domain.model;
 
+import java.time.Instant;
 import java.util.UUID;
 
 public class Ticket {
@@ -8,29 +9,81 @@ public class Ticket {
     private final String userId;
     private final String title;
     private final String description;
+    private final TicketStatus status;
+    private final String comment;
+    private final Instant createdAt;
+    private final Instant updatedAt;
 
-    private Ticket(String id, String userId, String title, String description) {
+    private Ticket(String id, String userId, String title, String description,
+                   TicketStatus status, String comment, Instant createdAt, Instant updatedAt){
         this.id = id;
         this.userId = userId;
         this.title = title;
         this.description = description;
+        this.status = status;
+        this.comment = comment;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 
     public static Ticket create(String userId, String title, String description) {
+        Instant now = Instant.now();
         return new Ticket(
                 UUID.randomUUID().toString(),
                 userId,
                 title,
-                description
+                description,
+                TicketStatus.OPEN,
+                null,
+                now,
+                now
         );
     }
 
+    @Deprecated
     public static Ticket restore(String id, String userId, String title, String description) {
-        return new Ticket(id, userId, title, description);
+        return new Ticket(
+                id,
+                userId,
+                title,
+                description,
+                TicketStatus.OPEN,
+                null,
+                Instant.now(),
+                Instant.now()
+        );
     }
 
-     public Ticket addComment(String comment) {
-        throw new UnsupportedOperationException("addComment is not implemented yet.");
+    public static Ticket restore(
+            String id, String userId, String title, String description,
+            TicketStatus status, String comment, Instant createdAt, Instant updatedAt) {
+        return new Ticket(id, userId, title, description, status, comment, createdAt, updatedAt);
+    }
+
+    public Ticket withComment(String comment) {
+        return new Ticket(
+                this.id,
+                this.userId,
+                this.title,
+                this.description,
+                this.status,
+                comment,
+                this.createdAt,
+                Instant.now()
+        );
+    }
+
+    public Ticket withStatus(TicketStatus status) {
+        return new Ticket(
+                this.id,
+                this.userId,
+                this.title,
+                this.description,
+                status,
+                this.comment,
+                this.createdAt,
+                Instant.now()
+        );
     }
 
     public String getId() {
@@ -47,5 +100,21 @@ public class Ticket {
 
     public String getDescription() {
         return description;
+    }
+
+    public TicketStatus getStatus() {
+        return status;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
@@ -21,15 +21,17 @@ class TicketTest {
         Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
         Ticket updated = ticket.withUpdates(null, "Mentor comment");
         assertEquals("Mentor comment", updated.getComment());
-        assertEquals(ticket.getStatus(), updated.getStatus()); // unchanged
+        assertEquals(ticket.getStatus(), updated.getStatus());
     }
+    
     @Test
     void withUpdates_should_update_only_status() {
         Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
         Ticket updated = ticket.withUpdates(TicketStatus.RESOLVED, null);
         assertEquals(TicketStatus.RESOLVED, updated.getStatus());
-        assertEquals(ticket.getComment(), updated.getComment()); // unchanged (null initially)
+        assertEquals(ticket.getComment(), updated.getComment()); 
     }
+    
     @Test
     void withUpdates_should_update_both_status_and_comment() {
         Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
@@ -37,6 +39,7 @@ class TicketTest {
         assertEquals(TicketStatus.IN_PROGRESS, updated.getStatus());
         assertEquals("Checking this", updated.getComment());
     }
+    
     @Test
     void withUpdates_should_not_change_anything_if_both_params_null() {
         Ticket ticket = Ticket.create("user-1", "Login issue", "desc");

--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
@@ -15,4 +15,13 @@ class TicketTest {
         assertEquals("Login issue", ticket.getTitle());
         assertEquals("Unable to access my account", ticket.getDescription());
     }
+    @Test
+    void addComment_shouldThrowUnsupportedOperationException() {
+        Ticket ticket = Ticket.create("user123", "Test Title", "Test Description");
+        UnsupportedOperationException exception = assertThrows(
+                UnsupportedOperationException.class,
+                () -> ticket.addComment("My comment")
+        );
+        assertEquals("addComment is not implemented yet.", exception.getMessage());
+    }    
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
@@ -15,31 +15,34 @@ class TicketTest {
         assertEquals("Login issue", ticket.getTitle());
         assertEquals("Unable to access my account", ticket.getDescription());
     }
-     @Test
-    void addComment_should_store_and_overwrite_comment() {
-        Ticket ticket = Ticket.create("user-1", "Login issue", "Unable to access my account");
-
-        Ticket commentedTicket = ticket.addComment("First comment");
-        assertEquals("First comment", commentedTicket.getComment());
-
-        Ticket overwrittenTicket = commentedTicket.addComment("Updated by mentor");
-        assertEquals("Updated by mentor", overwrittenTicket.getComment());
-
-        // old ticket keeps null comment (immutability demo)
-        assertNull(ticket.getComment());
-    }
 
     @Test
-    void setStatus_should_update_the_status() {
-        Ticket ticket = Ticket.create("user-1", "Login issue", "Unable to access my account");
-
-        Ticket toInProgress = ticket.setStatus(TicketStatus.IN_PROGRESS);
-        assertEquals(TicketStatus.IN_PROGRESS, toInProgress.getStatus());
-
-        Ticket toResolved = toInProgress.setStatus(TicketStatus.RESOLVED);
-        assertEquals(TicketStatus.RESOLVED, toResolved.getStatus());
-
-        // old ticket has status OPEN still
-        assertEquals(TicketStatus.OPEN, ticket.getStatus());
+    void withUpdates_should_update_only_comment() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
+        Ticket updated = ticket.withUpdates(null, "Mentor comment");
+        assertEquals("Mentor comment", updated.getComment());
+        assertEquals(ticket.getStatus(), updated.getStatus()); // unchanged
+    }
+    @Test
+    void withUpdates_should_update_only_status() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
+        Ticket updated = ticket.withUpdates(TicketStatus.RESOLVED, null);
+        assertEquals(TicketStatus.RESOLVED, updated.getStatus());
+        assertEquals(ticket.getComment(), updated.getComment()); // unchanged (null initially)
+    }
+    @Test
+    void withUpdates_should_update_both_status_and_comment() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
+        Ticket updated = ticket.withUpdates(TicketStatus.IN_PROGRESS, "Checking this");
+        assertEquals(TicketStatus.IN_PROGRESS, updated.getStatus());
+        assertEquals("Checking this", updated.getComment());
+    }
+    @Test
+    void withUpdates_should_not_change_anything_if_both_params_null() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "desc");
+        Ticket updated = ticket.withUpdates(null, null);
+        assertEquals(ticket.getStatus(), updated.getStatus());
+        assertEquals(ticket.getComment(), updated.getComment());
     }
 }
+

--- a/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/domain/model/TicketTest.java
@@ -15,13 +15,31 @@ class TicketTest {
         assertEquals("Login issue", ticket.getTitle());
         assertEquals("Unable to access my account", ticket.getDescription());
     }
+     @Test
+    void addComment_should_store_and_overwrite_comment() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "Unable to access my account");
+
+        Ticket commentedTicket = ticket.addComment("First comment");
+        assertEquals("First comment", commentedTicket.getComment());
+
+        Ticket overwrittenTicket = commentedTicket.addComment("Updated by mentor");
+        assertEquals("Updated by mentor", overwrittenTicket.getComment());
+
+        // old ticket keeps null comment (immutability demo)
+        assertNull(ticket.getComment());
+    }
+
     @Test
-    void addComment_shouldThrowUnsupportedOperationException() {
-        Ticket ticket = Ticket.create("user123", "Test Title", "Test Description");
-        UnsupportedOperationException exception = assertThrows(
-                UnsupportedOperationException.class,
-                () -> ticket.addComment("My comment")
-        );
-        assertEquals("addComment is not implemented yet.", exception.getMessage());
-    }    
+    void setStatus_should_update_the_status() {
+        Ticket ticket = Ticket.create("user-1", "Login issue", "Unable to access my account");
+
+        Ticket toInProgress = ticket.setStatus(TicketStatus.IN_PROGRESS);
+        assertEquals(TicketStatus.IN_PROGRESS, toInProgress.getStatus());
+
+        Ticket toResolved = toInProgress.setStatus(TicketStatus.RESOLVED);
+        assertEquals(TicketStatus.RESOLVED, toResolved.getStatus());
+
+        // old ticket has status OPEN still
+        assertEquals(TicketStatus.OPEN, ticket.getStatus());
+    }
 }


### PR DESCRIPTION
Ticket comments 

This PR introduces initial domain support for adding comments to a ticket.

A new addComment() method has been added to the Ticket aggregate as the first step toward allowing mentors to store feedback inside tickets.

The method currently returns this as a temporary placeholder because the Ticket aggregate does not yet include comment storage fields.
The goal of this PR is to introduce the domain behavior first and prepare the integration flow incrementally until the related model changes are merged.