### PR TITLE
feat(api): add find by id endpoint for tickets

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -10,7 +10,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/account/tickets")
@@ -91,4 +90,25 @@ public class TicketController {
                 })
                 .orElse(ResponseEntity.notFound().build());
     }
+
+    @GetMapping("/{id}")
+    public ResponseEntity <TicketResponse> findById( @PathVariable String id,
+                                                     @AuthenticationPrincipal OAuth2User user) {
+
+        if (user == null || user.getAttribute("login") == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        return ticketRepository.findById(id)
+                .map(ticket -> {
+                    return ResponseEntity.ok(new TicketResponse(
+                            ticket.getId(),
+                            ticket.getUserId(),
+                            ticket.getTitle(),
+                            ticket.getDescription()
+                    ));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -23,7 +22,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -122,5 +120,23 @@ class TicketControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateRequest)))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void should_return_200_with_ticket_when_requesting_ticket() throws Exception {
+
+        String ticketId = "ticket-123";
+        String ownerId = "user-11";
+
+        Ticket existingTicket = Ticket.restore(ticketId, ownerId, "Title for test", "Description for tests");
+
+        when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
+
+        mockMvc.perform(get("/api/account/tickets/{id}", ticketId)
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", ownerId))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(ownerId))
+                .andExpect(jsonPath("$.title").value("Title for test"))
+                .andExpect(jsonPath("$.description").value("Description for tests"));
     }
 }


### PR DESCRIPTION
Adds GET endpoint to retrieve a specific ticket by identifier with authentication validation. 
Returns 401 if user is not authenticated, 200 with ticket details if found, or 404 if ticket does not exist.

Includes integration test covering the happy path scenario and a mini refactor for unused imports.