### PR TITLE
Feat/779 navigate ticket details routerlink

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -8,11 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
-
 import org.springframework.http.HttpStatus;
-
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/account/tickets")
@@ -25,25 +23,25 @@ public class TicketController {
     }
 
     @PostMapping
-    public ResponseEntity<TicketResponse> createTicket(
+    @ResponseStatus(HttpStatus.CREATED)
+    public TicketResponse createTicket(
             @RequestBody TicketRequest request,
             @AuthenticationPrincipal OAuth2User user) {
 
         if (user == null || user.getAttribute("login") == null) {
-            return ResponseEntity.<TicketResponse>status(HttpStatus.UNAUTHORIZED).build();
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
 
         String userId = user.getAttribute("login");
-
-        Ticket newTicket = Ticket.create(userId, request.title(), request.description());
+        Ticket newTicket = Ticket.create(userId,request.title(), request.description());
         Ticket savedTicket = ticketRepository.save(newTicket);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new TicketResponse(
-                        savedTicket.getId(),
-                        savedTicket.getUserId(),
-                        savedTicket.getTitle(),
-                        savedTicket.getDescription()
-                ));
+
+        return new TicketResponse(
+                savedTicket.getId(),
+                savedTicket.getUserId(),
+                savedTicket.getTitle(),
+                savedTicket.getDescription()
+        );
     }
 
     @GetMapping

--- a/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
+++ b/frontend/src/app/features/tickets/data-access/ticket-api.service.ts
@@ -14,17 +14,11 @@ export class TicketApiService {
   private readonly ticketsUrl = '/api/account/tickets';
 
   create(ticket: ITicketRequest): Observable<ITicket> {
-    return this.http.post<ITicket>(this.ticketsUrl, ticket).pipe(
-      catchError(() => of({id: '1', userId: 'u-1', ...ticket} as ITicket))
-    );
+    return this.http.post<ITicket>(this.ticketsUrl, ticket)
   }
 
   loadAll(): Observable<ITicket[]> {
-    return this.http.get<ITicket[]>(this.ticketsUrl).pipe(
-      catchError((error: HttpErrorResponse) => {
-        return of(TICKETS_MOCK);
-      })
-    );
+    return this.http.get<ITicket[]>(this.ticketsUrl)
   }
 
   update(id: string, data: Partial<ITicket>): Observable<ITicket> {

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.html
@@ -6,5 +6,6 @@
             <h3>{{ ticket.title }}</h3>
             <p>{{ ticket.description }}</p>
         </li>
+        <button [routerLink]="['/tickets', ticket.id]">Accedir al ticket</button>
     }
 </ul>

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
@@ -50,4 +50,9 @@ describe('TicketListPage', () => {
     expect(compiled.textContent).toContain(firstTicket.title);
     expect(compiled.textContent).toContain(firstTicket.description);
   });
+
+  it('should have a routerLink button for each ticket', () => {
+  const links = fixture.debugElement.queryAll(By.directive(RouterLink));
+  expect(links.length).toBe(TICKETS_MOCK.length);
+  });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
@@ -4,6 +4,8 @@ import { of } from 'rxjs';
 import { TicketListPage } from './ticket-list-page';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { TICKETS_MOCK } from '../../models/tickets.mock';
+import { provideRouter, RouterLink } from '@angular/router';
+import { By } from '@angular/platform-browser';
 
 describe('TicketListPage', () => {
   let component: TicketListPage;
@@ -16,7 +18,8 @@ describe('TicketListPage', () => {
     await TestBed.configureTestingModule({
       imports: [TicketListPage],
       providers: [
-        { provide: TicketApiService, useValue: mockTicketApiService }
+        { provide: TicketApiService, useValue: mockTicketApiService },
+        provideRouter([])
       ]
     }).compileComponents();
 
@@ -45,5 +48,10 @@ describe('TicketListPage', () => {
 
     expect(compiled.textContent).toContain(firstTicket.title);
     expect(compiled.textContent).toContain(firstTicket.description);
+  });
+
+  it('should have routerLink buttons for each challenge', () => {
+    const links = fixture.debugElement.queryAll(By.directive(RouterLink));
+    expect(links.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.ts
@@ -1,11 +1,12 @@
 import { Component, inject, signal } from '@angular/core';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { ITicket } from '../../models/iticket.interface';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-ticket-list-page',
   standalone: true,
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './ticket-list-page.html',
   styleUrl: './ticket-list-page.css',
 })


### PR DESCRIPTION
Task #779 

### Description
Added dynamic navigation from the ticket list view to the individual ticket details page using Angular's routerLink.

### Done:

- Added navigation button to ticket-list-page.html with dynamic pathing (['/tickets', ticket.id]).

- Testing

**Note:** 

- Shared root or external feature test failures (auth/challenges) are unrelated to this branch's changes. 
-  The current PR has commits from ticket scaffolding PR #792  , one scaffolding is merged this PR will be shorter. **RESOLVED**