### PR TITLE
chore(challenges): add solution field to interfaces and mock, update form logic and template, adjust tests (#808)

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -153,7 +153,7 @@ describe('ChallengeApiService', () => {
 
     service.postSolution(payload).subscribe();
 
-    const req = httpTestingController.expectOne(`${apiUrl}/submissions`);
+    const req = httpTestingController.expectOne(`${apiUrl}/submissions/finalize`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(payload);
     req.flush(null);

--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -35,7 +35,8 @@ describe('ChallengeApiService', () => {
     const testId = 'abc-123';
     const updateData: IChallengeRequest = {
       title: 'Updated Challenge',
-      description: 'New Description'
+      description: 'New Description',
+      solution: 'solution',
     };
 
     it('should call PUT with correct URL and body', () => {
@@ -67,7 +68,7 @@ describe('ChallengeApiService', () => {
 
   describe('create', () => {
     it('should call POST with the correct URL and body and return the created challenge', () => {
-      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc', solution: 'solution' };
       const mockResponse: IChallenge = { id: '1', ...newChallenge };
 
       service.create(newChallenge).subscribe(result => {
@@ -81,7 +82,7 @@ describe('ChallengeApiService', () => {
     });
 
     it('should return default challenge when API fails (Happy Path Fallback)', () => {
-      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc', solution: 'solution' };
 
       service.create(newChallenge).subscribe(response => {
         expect(response.id).toBe('1');
@@ -152,7 +153,7 @@ describe('ChallengeApiService', () => {
 
     service.postSolution(payload).subscribe();
 
-    const req = httpTestingController.expectOne(`${apiUrl}/submissions/finalize`);
+    const req = httpTestingController.expectOne(`${apiUrl}/submissions`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(payload);
     req.flush(null);

--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
@@ -20,6 +20,7 @@ export class ChallengeApiService {
           id: '1',
           title: challenge.title,
           description: challenge.description,
+          solution: challenge.solution,
         });
       }),
     );
@@ -40,6 +41,7 @@ export class ChallengeApiService {
           id: id,
           title: challenge.title,
           description: challenge.description,
+          solution: challenge.solution,
         }),
       ),
     );

--- a/frontend/src/app/features/challenges/models/challenges.mock.ts
+++ b/frontend/src/app/features/challenges/models/challenges.mock.ts
@@ -4,16 +4,19 @@ export const CHALLENGES_MOCK: IChallenge[] = [
   {
     id: "1",
     title: "primer",
-    description: "descripció 1"
+    description: "descripció 1",
+    solution: 'solució 1',
   },
   {
     id: "2",
     title: "segon",
-    description: "descripció 2"
+    description: "descripció 2",
+    solution: 'solució 2',
   },
   {
     id: "3",
     title: "tercer",
-    description: "descripció 3"
+    description: "descripció 3",
+    solution: 'solució 3',
   },
 ];

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -1,4 +1,5 @@
 export interface IChallengeRequest {
-    title: string, 
-	description: string,
+    title: string;
+    description: string;
+    solution?: string;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,5 +1,6 @@
 export interface IChallenge {
-    id: string, 
-    title: string, 
-	description: string,
+    id: string;
+    title: string;
+    description: string;
+    solution?: string;
 }

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
@@ -9,5 +9,10 @@
     <input type="text" id="description" formControlName="description">
   </div>
 
+  <div>
+    <label for="solution">Solució oficial</label>
+    <textarea id="solution" formControlName="solution"></textarea>
+  </div>
+
   <button type="submit">Crear</button>
 </form>

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
@@ -13,7 +13,7 @@ describe('CreateChallengePage', () => {
   beforeEach(async () => {
 
     mockChallengeService = {
-      create: () => of({ id: '1', title: '', description: '' })
+      create: () => of({ id: '1', title: '', description: '', solution: '' })
     };
 
     mockRouter = {
@@ -41,9 +41,11 @@ describe('CreateChallengePage', () => {
   it('should start the form with empty fields', () => {
     const title = component.challengeForm.get('title');
     const description = component.challengeForm.get('description');
+    const solution = component.challengeForm.get('solution');
 
     expect(title?.value).toBe('');
     expect(description?.value).toBe('');
+    expect(solution?.value).toBe('');
   });
 
   it('should call onSubmit when form is submitted', () => {
@@ -56,7 +58,7 @@ describe('CreateChallengePage', () => {
   });
 
   it('should call challengeService.create when call onSubmit with correct data', () => {
-    const testData = { title: 'Nou Repte', description: 'Descripció' };
+    const testData = { title: 'Nou Repte', description: 'Descripció', solution: 'Solució' };
     component.challengeForm.setValue(testData);
 
     vi.spyOn(mockChallengeService, 'create').mockReturnValue(of({ id: '1', ...testData }));

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -18,7 +18,8 @@ export class CreateChallengePage {
 
   challengeForm = this.fb.group({
     title: [''],
-    description: ['']
+    description: [''],
+    solution: [''],
   })
 
   onSubmit() {

--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -37,10 +37,11 @@ describe('ChallengeService', () => {
       const testId = '123';
       const testChallenge: IChallengeRequest = {
         title: 'New Title',
-        description: 'New description'
+        description: 'New description',
+        solution: `New solution`
       };
 
-      vi.mocked(mockChallengeApiService.update!).mockImplementation((id, data) =>
+      mockChallengeApiService.update = vi.fn((id, data) =>
         of({ id, ...data } as IChallenge)
       );
 
@@ -58,9 +59,9 @@ describe('ChallengeService', () => {
 
   describe('create', () => {
     it('should call challengeApiService.create with correct data and return the observable', () => {
-      const newChallenge: IChallengeRequest = { title: 'New', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'New', description: 'Desc', solution: 'this' };
 
-      vi.mocked(mockChallengeApiService.create!).mockImplementation((data) =>
+      mockChallengeApiService.create = vi.fn((data) =>
         of({ id: '1', ...data } as IChallenge)
       );
 


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/808)

## Summary
Introduced the `solution` optional field to the challenge domain models and updated the core data structures, forms, and tests to support official solution content.  

This is a backward-compatible update to prepare the system for future challenge creation and evaluation features.

## What's included
- Extended `IChallengeRequest` interface with `solution?`
- Extended `IChallenge` interface with `solution?`
- Updated `CHALLENGES_MOCK` to include `solution` values
- Updated `CreateChallengePage` form TS logic to handle `solution`
- Updated form template HTML with textarea for `solution`
- Updated relevant tests to accommodate the new `solution` field

> The new field is defined as optional (?) as a transitional strategy, allowing the system to evolve without breaking existing forms, services, or mocks while integration is gradually completed.
