### PR TITLE
chore(challenges): add difficulty field to interfaces and mock, update form logic and template, adjust tests (#809)

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -35,7 +35,8 @@ describe('ChallengeApiService', () => {
     const testId = 'abc-123';
     const updateData: IChallengeRequest = {
       title: 'Updated Challenge',
-      description: 'New Description'
+      description: 'New Description',
+      difficulty: 'EASY',
     };
 
     it('should call PUT with correct URL and body', () => {
@@ -81,7 +82,7 @@ describe('ChallengeApiService', () => {
     });
 
     it('should return default challenge when API fails (Happy Path Fallback)', () => {
-      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc', difficulty: 'EASY' };
 
       service.create(newChallenge).subscribe(response => {
         expect(response.id).toBe('1');

--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
@@ -20,6 +20,7 @@ export class ChallengeApiService {
           id: '1',
           title: challenge.title,
           description: challenge.description,
+          difficulty: challenge.difficulty,
         });
       }),
     );
@@ -40,6 +41,7 @@ export class ChallengeApiService {
           id: id,
           title: challenge.title,
           description: challenge.description,
+          difficulty: challenge.difficulty,
         }),
       ),
     );

--- a/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-difficulty.type.ts
@@ -1,0 +1,1 @@
+export type ChallengeDifficulty = 'EASY' | 'MEDIUM' | 'HARD';

--- a/frontend/src/app/features/challenges/models/challenges.mock.ts
+++ b/frontend/src/app/features/challenges/models/challenges.mock.ts
@@ -4,16 +4,19 @@ export const CHALLENGES_MOCK: IChallenge[] = [
   {
     id: "1",
     title: "primer",
-    description: "descripció 1"
+    description: "descripció 1",
+    difficulty: 'EASY',
   },
   {
     id: "2",
     title: "segon",
-    description: "descripció 2"
+    description: "descripció 2",
+    difficulty: 'MEDIUM',
   },
   {
     id: "3",
     title: "tercer",
-    description: "descripció 3"
+    description: "descripció 3",
+    difficulty: 'HARD',
   },
 ];

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -1,4 +1,7 @@
+import { ChallengeDifficulty } from "./challenge-difficulty.type";
+
 export interface IChallengeRequest {
-    title: string, 
-	description: string,
+    title: string;
+    description: string;
+    difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,5 +1,8 @@
+import { ChallengeDifficulty } from "./challenge-difficulty.type";
+
 export interface IChallenge {
-    id: string, 
-    title: string, 
-	description: string,
+    id: string;
+    title: string;
+    description: string;
+    difficulty?: ChallengeDifficulty;
 }

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
@@ -12,10 +12,12 @@
   <div>
     <label for="difficulty">Dificultat</label>
     <select id="difficulty" formControlName="difficulty">
-      <option value="" selected disabled>Selecciona dificultat</option>
-      <option value="EASY">Easy</option>
-      <option value="MEDIUM">Medium</option>
-      <option value="HARD">Hard</option>
+      <option value="" disabled>Selecciona dificultat</option>
+      @for (difficulty of difficulties; track difficulty) {
+        <option [value]="difficulty">
+          {{ difficulty }}
+        </option>
+      }
     </select>
   </div>
 

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
@@ -9,5 +9,15 @@
     <input type="text" id="description" formControlName="description">
   </div>
 
+  <div>
+    <label for="difficulty">Dificultat</label>
+    <select id="difficulty" formControlName="difficulty">
+      <option value="" selected disabled>Selecciona dificultat</option>
+      <option value="EASY">Easy</option>
+      <option value="MEDIUM">Medium</option>
+      <option value="HARD">Hard</option>
+    </select>
+  </div>
+
   <button type="submit">Crear</button>
 </form>

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
@@ -3,6 +3,7 @@ import { CreateChallengePage } from './create-challenge-page';
 import { ChallengeService } from '../../services/challenge.service';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
+import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 
 describe('CreateChallengePage', () => {
   let component: CreateChallengePage;
@@ -13,7 +14,7 @@ describe('CreateChallengePage', () => {
   beforeEach(async () => {
 
     mockChallengeService = {
-      create: () => of({ id: '1', title: '', description: '' })
+      create: () => of({ id: '1', title: '', description: '', difficulty: 'EASY' })
     };
 
     mockRouter = {
@@ -41,9 +42,11 @@ describe('CreateChallengePage', () => {
   it('should start the form with empty fields', () => {
     const title = component.challengeForm.get('title');
     const description = component.challengeForm.get('description');
+    const difficulty = component.challengeForm.get('difficulty');
 
     expect(title?.value).toBe('');
     expect(description?.value).toBe('');
+    expect(difficulty?.value).toBe('');
   });
 
   it('should call onSubmit when form is submitted', () => {
@@ -56,7 +59,7 @@ describe('CreateChallengePage', () => {
   });
 
   it('should call challengeService.create when call onSubmit with correct data', () => {
-    const testData = { title: 'Nou Repte', description: 'Descripció' };
+    const testData = { title: 'Nou Repte', description: 'Descripció', difficulty: 'EASY' as ChallengeDifficulty };
     component.challengeForm.setValue(testData);
 
     vi.spyOn(mockChallengeService, 'create').mockReturnValue(of({ id: '1', ...testData }));

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -3,6 +3,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { IChallengeRequest } from '../../models/ichallenge-request.interface';
 import { ChallengeService } from '../../services/challenge.service';
 import { Router } from '@angular/router';
+import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 
 @Component({
   selector: 'app-create-challenge-page',
@@ -15,6 +16,8 @@ export class CreateChallengePage {
   readonly challengeService = inject(ChallengeService)
   readonly router = inject(Router)
   readonly fb = inject(FormBuilder)
+
+  difficulties: ChallengeDifficulty[] = ['EASY', 'MEDIUM', 'HARD'];
 
   challengeForm = this.fb.group({
     title: [''],

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -17,7 +17,7 @@ export class CreateChallengePage {
   readonly router = inject(Router)
   readonly fb = inject(FormBuilder)
 
-  difficulties: ChallengeDifficulty[] = ['EASY', 'MEDIUM', 'HARD'];
+  readonly difficulties: ChallengeDifficulty[] = ['EASY', 'MEDIUM', 'HARD'];
 
   challengeForm = this.fb.group({
     title: [''],

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -18,7 +18,8 @@ export class CreateChallengePage {
 
   challengeForm = this.fb.group({
     title: [''],
-    description: ['']
+    description: [''],
+    difficulty: [''],
   })
 
   onSubmit() {


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/809)

## Summary
Introduced the `difficulty` optional field to the challenge domain models and updated form and mock to allow setting the difficulty level for each challenge.  

This change is backward-compatible and prepares the UI and backend for structured difficulty handling.

## What's included
- Added `ChallengeDifficulty` type (`EASY | MEDIUM | HARD`)
- Extended `IChallengeRequest` interface with `difficulty?`
- Extended `IChallenge` interface with `difficulty?`
- Updated `CHALLENGES_MOCK` to include `difficulty`
- Updated `CreateChallengePage` form TS logic to handle `difficulty`
- Updated form template HTML with select dropdown for `difficulty`
- Updated relevant tests to accommodate the new `difficulty` field

> The new field is optional (?) to prevent breaking existing functionality and allow incremental UI and backend integration.