### PR TITLE
chore(challenges): add language field to interfaces and mock, update form logic and template, adjust tests (#810)

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -35,7 +35,8 @@ describe('ChallengeApiService', () => {
     const testId = 'abc-123';
     const updateData: IChallengeRequest = {
       title: 'Updated Challenge',
-      description: 'New Description'
+      description: 'New Description',
+      language: 'JAVA',
     };
 
     it('should call PUT with correct URL and body', () => {
@@ -81,11 +82,12 @@ describe('ChallengeApiService', () => {
     });
 
     it('should return default challenge when API fails (Happy Path Fallback)', () => {
-      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'Test', description: 'Desc', language: 'JAVA' };
 
       service.create(newChallenge).subscribe(response => {
         expect(response.id).toBe('1');
         expect(response.title).toBe(newChallenge.title);
+        expect(response.language).toBe(newChallenge.language);
       });
 
       const req = httpTestingController.expectOne(apiUrl);

--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
@@ -20,6 +20,7 @@ export class ChallengeApiService {
           id: '1',
           title: challenge.title,
           description: challenge.description,
+          language: challenge.language,
         });
       }),
     );
@@ -40,6 +41,7 @@ export class ChallengeApiService {
           id: id,
           title: challenge.title,
           description: challenge.description,
+          language: challenge.language,
         }),
       ),
     );

--- a/frontend/src/app/features/challenges/models/challenge-language.type.ts
+++ b/frontend/src/app/features/challenges/models/challenge-language.type.ts
@@ -1,0 +1,1 @@
+export type ChallengeLanguage = 'JAVA' | 'PHP' | 'JAVASCRIPT' | 'TYPESCRIPT' | 'PYTHON' | 'SQL';

--- a/frontend/src/app/features/challenges/models/challenges.mock.ts
+++ b/frontend/src/app/features/challenges/models/challenges.mock.ts
@@ -4,16 +4,19 @@ export const CHALLENGES_MOCK: IChallenge[] = [
   {
     id: "1",
     title: "primer",
-    description: "descripció 1"
+    description: "descripció 1",
+    language: 'TYPESCRIPT',
   },
   {
     id: "2",
     title: "segon",
-    description: "descripció 2"
+    description: "descripció 2",
+    language: 'JAVA',
   },
   {
     id: "3",
     title: "tercer",
-    description: "descripció 3"
+    description: "descripció 3",
+    language: 'PHP',
   },
 ];

--- a/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge-request.interface.ts
@@ -1,4 +1,7 @@
+import { ChallengeLanguage } from "./challenge-language.type";
+
 export interface IChallengeRequest {
-    title: string, 
-	description: string,
+    title: string;
+    description: string;
+    language?: ChallengeLanguage;
 }

--- a/frontend/src/app/features/challenges/models/ichallenge.interface.ts
+++ b/frontend/src/app/features/challenges/models/ichallenge.interface.ts
@@ -1,5 +1,8 @@
+import { ChallengeLanguage } from "./challenge-language.type";
+
 export interface IChallenge {
-    id: string, 
-    title: string, 
-	description: string,
+    id: string;
+    title: string;
+    description: string;
+    language?: ChallengeLanguage;
 }

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
@@ -9,5 +9,18 @@
     <input type="text" id="description" formControlName="description">
   </div>
 
+  <div>
+    <label for="language">Llenguatge</label>
+    <select id="language" formControlName="language">
+      <option value="" selected disabled>Selecciona llenguatge</option>
+      <option value="JAVA">Java</option>
+      <option value="PHP">PHP</option>
+      <option value="JAVASCRIPT">JavaScript</option>
+      <option value="TYPESCRIPT">TypeScript</option>
+      <option value="PYTHON">Python</option>
+      <option value="SQL">SQL</option>
+    </select>
+  </div>
+
   <button type="submit">Crear</button>
 </form>

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.html
@@ -13,12 +13,11 @@
     <label for="language">Llenguatge</label>
     <select id="language" formControlName="language">
       <option value="" selected disabled>Selecciona llenguatge</option>
-      <option value="JAVA">Java</option>
-      <option value="PHP">PHP</option>
-      <option value="JAVASCRIPT">JavaScript</option>
-      <option value="TYPESCRIPT">TypeScript</option>
-      <option value="PYTHON">Python</option>
-      <option value="SQL">SQL</option>
+      @for (language of languages; track language) {
+        <option [value]="language">
+          {{ language }}
+        </option>
+      }
     </select>
   </div>
 

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.spec.ts
@@ -3,6 +3,7 @@ import { CreateChallengePage } from './create-challenge-page';
 import { ChallengeService } from '../../services/challenge.service';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
+import { ChallengeLanguage } from '../../models/challenge-language.type';
 
 describe('CreateChallengePage', () => {
   let component: CreateChallengePage;
@@ -13,7 +14,7 @@ describe('CreateChallengePage', () => {
   beforeEach(async () => {
 
     mockChallengeService = {
-      create: () => of({ id: '1', title: '', description: '' })
+      create: () => of({ id: '1', title: '', description: '', language: 'JAVA' })
     };
 
     mockRouter = {
@@ -41,9 +42,11 @@ describe('CreateChallengePage', () => {
   it('should start the form with empty fields', () => {
     const title = component.challengeForm.get('title');
     const description = component.challengeForm.get('description');
+    const language = component.challengeForm.get('language');
 
     expect(title?.value).toBe('');
     expect(description?.value).toBe('');
+    expect(language?.value).toBe('');
   });
 
   it('should call onSubmit when form is submitted', () => {
@@ -56,7 +59,7 @@ describe('CreateChallengePage', () => {
   });
 
   it('should call challengeService.create when call onSubmit with correct data', () => {
-    const testData = { title: 'Nou Repte', description: 'Descripció' };
+    const testData = { title: 'Nou Repte', description: 'Descripció', language: 'JAVA' as ChallengeLanguage };
     component.challengeForm.setValue(testData);
 
     vi.spyOn(mockChallengeService, 'create').mockReturnValue(of({ id: '1', ...testData }));

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -18,7 +18,8 @@ export class CreateChallengePage {
 
   challengeForm = this.fb.group({
     title: [''],
-    description: ['']
+    description: [''],
+    language: [''],
   })
 
   onSubmit() {

--- a/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/create-challenge-page/create-challenge-page.ts
@@ -3,6 +3,7 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { IChallengeRequest } from '../../models/ichallenge-request.interface';
 import { ChallengeService } from '../../services/challenge.service';
 import { Router } from '@angular/router';
+import { ChallengeLanguage } from '../../models/challenge-language.type';
 
 @Component({
   selector: 'app-create-challenge-page',
@@ -15,6 +16,8 @@ export class CreateChallengePage {
   readonly challengeService = inject(ChallengeService)
   readonly router = inject(Router)
   readonly fb = inject(FormBuilder)
+
+  readonly languages: ChallengeLanguage[] = ['JAVA', 'PHP', 'JAVASCRIPT', 'TYPESCRIPT', 'PYTHON', 'SQL'];
 
   challengeForm = this.fb.group({
     title: [''],

--- a/frontend/src/app/features/challenges/services/challenge.service.spec.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.spec.ts
@@ -37,7 +37,8 @@ describe('ChallengeService', () => {
       const testId = '123';
       const testChallenge: IChallengeRequest = {
         title: 'New Title',
-        description: 'New description'
+        description: 'New description',
+        language: 'JAVA',
       };
 
       vi.mocked(mockChallengeApiService.update!).mockImplementation((id, data) =>
@@ -58,7 +59,7 @@ describe('ChallengeService', () => {
 
   describe('create', () => {
     it('should call challengeApiService.create with correct data and return the observable', () => {
-      const newChallenge: IChallengeRequest = { title: 'New', description: 'Desc' };
+      const newChallenge: IChallengeRequest = { title: 'New', description: 'Desc', language: 'JAVA' };
 
       vi.mocked(mockChallengeApiService.create!).mockImplementation((data) =>
         of({ id: '1', ...data } as IChallenge)
@@ -71,6 +72,7 @@ describe('ChallengeService', () => {
       result.subscribe(response => {
         expect(response.title).toBe(newChallenge.title);
         expect(response.description).toBe(newChallenge.description);
+        expect(response.language).toBe(newChallenge.language);
       });
     });
   });


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/810)

## Summary
Introduced the `language` optional field to the challenge domain models and updated forms and mocks to allow selecting the programming language for each challenge.  

This change is backward-compatible and prepares the system for structured language handling in the UI and backend.

## What's included
- Added `ChallengeLanguage` type (`JAVA | PHP | JAVASCRIPT | TYPESCRIPT | PYTHON | SQL`)
- Extended `IChallengeRequest` interface with `language?`
- Extended `IChallenge` interface with `language?`
- Updated `CHALLENGES_MOCK` to include `language`
- Updated `CreateChallengePage` form TS logic to handle `language`
- Updated form template HTML with select dropdown for `language`
- Updated relevant tests to accommodate the new `language` field

> The new field is optional (?) to prevent breaking existing functionality and allow incremental UI and backend integration.