### PR TITLE
Feature: add ChallengeLanguage to Challenge domain entity (Part of #719)

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/model/Challenge.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/model/Challenge.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.domain.model;
 
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeTitle;
 import lombok.Getter;
 
@@ -11,26 +12,30 @@ public class Challenge {
     private final ChallengeId id;
     private final ChallengeTitle title;
     private final ChallengeDescription description;
+    private final ChallengeLanguage language;
 
-    private Challenge(ChallengeId id, ChallengeTitle title, ChallengeDescription description) {
+    private Challenge(ChallengeId id, ChallengeTitle title, ChallengeDescription description, ChallengeLanguage language) {
         this.id = id;
         this.title = title;
         this.description = description;
+        this.language = language;
     }
 
-    public static Challenge create(String title, String description) {
+    public static Challenge create(String title, String description, ChallengeLanguage language) {
         return new Challenge(
                 ChallengeId.generate(),
                 new ChallengeTitle(title),
-                new ChallengeDescription(description)
+                new ChallengeDescription(description),
+                language
         );
     }
 
-    public static Challenge restore(ChallengeId id, String title, String description) {
+    public static Challenge restore(ChallengeId id, String title, String description, ChallengeLanguage language) {
         return new Challenge(
                 id,
                 new ChallengeTitle(title),
-                new ChallengeDescription(description)
+                new ChallengeDescription(description),
+                language
         );
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeResponse;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
 import lombok.AllArgsConstructor;
@@ -23,7 +24,7 @@ public class ChallengeController {
     @PostMapping
     public ResponseEntity<ChallengeResponse> create(@RequestBody ChallengeRequest request) {
         Challenge saved = repository.save(
-                Challenge.create(request.title(), request.description())
+                Challenge.create(request.title(), request.description(), ChallengeLanguage.JAVA)
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
@@ -73,7 +74,8 @@ public class ChallengeController {
         Challenge challenge = Challenge.restore(
                 new ChallengeId(UUID.fromString(id)),
                 request.title(),
-                request.description()
+                request.description(),
+                ChallengeLanguage.JAVA
         );
 
         Challenge updated = repository.update(challenge);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
@@ -87,7 +88,8 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
                         Challenge.restore(
                                 ChallengeId.of(r.id()),
                                 r.title(),
-                                r.description())));
+                                r.description(),
+                                ChallengeLanguage.JAVA)));
     }
 
     record ChallengeRecord(String id, String title, String description) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.io.ClassPathResource;
@@ -32,7 +33,8 @@ public class ChallengeSeedLoader implements ApplicationRunner {
                     .map(seed -> Challenge.restore(
                             ChallengeId.of(seed.id()),
                             seed.title(),
-                            seed.description()
+                            seed.description(),
+                            ChallengeLanguage.JAVA
                     ))
                     .forEach(repository::save);
         }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.ou
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,7 @@ class InMemoryChallengeRepositoryTest {
     @BeforeEach
     void setUp() {
         repository = new InMemoryChallengeRepository();
-        challenge = Challenge.create("Clean Code Challenge", "A challenge about writing clean and maintainable code");
+        challenge = Challenge.create("Clean Code Challenge", "A challenge about writing clean and maintainable code", ChallengeLanguage.JAVA);
     }
 
     @Test
@@ -30,7 +31,7 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_create_new_challenge() {
-        Challenge newChallenge = Challenge.create("New Challenge Title", "New Challenge Description");
+        Challenge newChallenge = Challenge.create("New Challenge Title", "New Challenge Description", ChallengeLanguage.JAVA);
         Challenge result = repository.save(newChallenge);
 
         assertThat(result.getTitle().toString()).isEqualTo("New Challenge Title");
@@ -39,12 +40,13 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_update_existing_challenge() {
-        Challenge original = repository.save(Challenge.create("Old title", "Old description"));
+        Challenge original = repository.save(Challenge.create("Old title", "Old description", ChallengeLanguage.JAVA));
 
         Challenge updated = Challenge.restore(
                 original.getId(),
                 "New title",
-                "New description"
+                "New description",
+                ChallengeLanguage.JAVA
         );
 
         Challenge result = repository.update(updated);
@@ -57,7 +59,7 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_delete_existing_challenge() {
-        Challenge challenge = Challenge.create("To be deleted", "Description");
+        Challenge challenge = Challenge.create("To be deleted", "Description", ChallengeLanguage.JAVA);
 
         ChallengeId id = challenge.getId();
         repository.save(challenge);

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.ou
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ class JsonFileChallengeRepositoryTest {
 
         Challenge challenge = Challenge.create(
                 "Clean Code",
-                "Write readable code"
+                "Write readable code",
+                ChallengeLanguage.JAVA
         );
 
         repository.save(challenge);

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -5,6 +5,7 @@ import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepos
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeTitle;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller.ChallengeController;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
@@ -53,7 +54,7 @@ class ChallengeControllerTest {
 
     @Test
     void should_create_challenge_with_title_and_description_and_return_201() throws Exception {
-        Challenge saved = Challenge.create(request.title(), request.description());
+        Challenge saved = Challenge.create(request.title(), request.description(), ChallengeLanguage.JAVA);
         when(repository.save(any(Challenge.class))).thenReturn(saved);
 
         mockMvc.perform(post("/api/challenge")
@@ -85,7 +86,8 @@ class ChallengeControllerTest {
         Challenge updatedChallenge = Challenge.restore(
                 new ChallengeId(UUID.fromString(id)),
                 "Updated title",
-                "Updated description"
+                "Updated description",
+                ChallengeLanguage.JAVA
         );
 
         when(repository.update(any(Challenge.class)))


### PR DESCRIPTION
## Objective
This Pull Request implements the second phase of story **#719**. It introduces the `ChallengeLanguage` concept directly into the core of our Hexagonal Architecture (Domain Layer), making it a strict requirement when creating or restoring a challenge.

## Changes Made
- **Domain (`Challenge.java`):** Added `ChallengeLanguage` as a `final` attribute. Updated the private constructor and the factory methods (`create` and `restore`).
- **Tests:** Refactored all domain and infrastructure tests (`ChallengeTest`, `ChallengeControllerTest`, `InMemoryChallengeRepositoryTest`, etc.) by injecting a default language so they successfully compile and pass.
- **Infrastructure (`ChallengeSeedLoader`, `JsonFileChallengeRepository`, `ChallengeController`):** Adapted the code to comply with the new domain rules.

## Important Note for Reviewers (Architecture)
To keep this PR atomic and strictly focused on the **Domain**, the value `ChallengeLanguage.JAVA` has been temporarily hardcoded in the infrastructure layer (Controller, JSON persistence, and Seed). 

The DTO (`ChallengeRequest`) has intentionally been left untouched in this branch. The dynamic binding between the DTO and the Controller, using the actual language sent by the client, will be addressed in the next sub-task/PR of this story.

## Related to:
Part of #719