### PR TITLE
feat(ticketing): implement getByID ticket function #779

### DIFF
--- a/frontend/src/app/features/tickets/ticket.service.spec.ts
+++ b/frontend/src/app/features/tickets/ticket.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Ticket } from './ticket.service';
+import { TICKETS_MOCK } from './models/tickets.mock';
+import { firstValueFrom, of } from 'rxjs';
+import { TicketApiService } from './data-access/ticket-api.service';
+
+describe('Ticket', () => {
+  let service: Ticket;
+  let mockTicketApiService: any;
+
+  beforeEach(() => {
+    mockTicketApiService = {
+      loadAll: vi.fn().mockReturnValue(of(TICKETS_MOCK))
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: TicketApiService, useValue: mockTicketApiService }
+      ]
+    });
+    service = TestBed.inject(Ticket);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return ticket by id', async () => {
+    const ticket = await firstValueFrom(service.getById('1'));
+    expect(ticket).toEqual(TICKETS_MOCK[0]);
+  });
+
+  it('should return undefined when ticket not found', async () => {
+    const ticket = await firstValueFrom(service.getById('999'));
+    expect(ticket).toBeUndefined();
+  });
+});

--- a/frontend/src/app/features/tickets/ticket.service.spec.ts
+++ b/frontend/src/app/features/tickets/ticket.service.spec.ts
@@ -1,12 +1,11 @@
 import { TestBed } from '@angular/core/testing';
-
-import { Ticket } from './ticket.service';
+import { TicketService } from './ticket.service';
 import { TICKETS_MOCK } from './models/tickets.mock';
 import { firstValueFrom, of } from 'rxjs';
 import { TicketApiService } from './data-access/ticket-api.service';
 
 describe('Ticket', () => {
-  let service: Ticket;
+  let service: TicketService;
   let mockTicketApiService: any;
 
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('Ticket', () => {
         { provide: TicketApiService, useValue: mockTicketApiService }
       ]
     });
-    service = TestBed.inject(Ticket);
+    service = TestBed.inject(TicketService);
   });
 
   it('should be created', () => {

--- a/frontend/src/app/features/tickets/ticket.service.ts
+++ b/frontend/src/app/features/tickets/ticket.service.ts
@@ -1,0 +1,19 @@
+import { inject, Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+import { IChallenge } from '../challenges/models/ichallenge.interface';
+import { TicketApiService } from './data-access/ticket-api.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class Ticket {
+
+  private readonly ticketApiService = inject(TicketApiService)
+
+  getById(id: string): Observable<IChallenge | undefined> {
+      return this.ticketApiService.loadAll().pipe(
+        map((tickets) => tickets.find(((ticket) => ticket.id === id)))
+      )
+    }
+
+}

--- a/frontend/src/app/features/tickets/ticket.service.ts
+++ b/frontend/src/app/features/tickets/ticket.service.ts
@@ -1,16 +1,16 @@
 import { inject, Injectable } from '@angular/core';
 import { map, Observable } from 'rxjs';
-import { IChallenge } from '../challenges/models/ichallenge.interface';
 import { TicketApiService } from './data-access/ticket-api.service';
+import { ITicket } from './models/iticket.interface';
 
 @Injectable({
   providedIn: 'root',
 })
-export class Ticket {
+export class TicketService {
 
   private readonly ticketApiService = inject(TicketApiService)
 
-  getById(id: string): Observable<IChallenge | undefined> {
+  getById(id: string): Observable<ITicket | undefined> {
       return this.ticketApiService.loadAll().pipe(
         map((tickets) => tickets.find(((ticket) => ticket.id === id)))
       )


### PR DESCRIPTION
#779 Task

## Description
Implemented `getById()` method in Ticket service to fetch a specific ticket by its ID.

## Done
- Added `getById(id: string)` method that filters tickets from `loadAll()`
- Method returns `Observable<ITicket | undefined>`
- Returns undefined when ticket is not found

## Note:

Shared root or external feature test failures (auth/challenges) are unrelated to this branch's changes. 