### PR TITLE
fix(ticket): fix create ticket persistence and add missing response f…

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -30,12 +30,13 @@ public class TicketController {
             @AuthenticationPrincipal OAuth2User user) {
 
         String userId = user != null ? user.getAttribute("login") : "temp-user";
-
+        Ticket newTicket = Ticket.create(userId, request.title(), request.description());
+        Ticket savedTicket = ticketRepository.save(newTicket);
         return new TicketResponse(
-                "temp-id",
-                userId,
-                request.title(),
-                request.description()
+                savedTicket.getId(),
+                savedTicket.getUserId(),
+                savedTicket.getTitle(),
+                savedTicket.getDescription()
         );
     }
 

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -8,9 +8,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
+
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
+
 
 @RestController
 @RequestMapping("/api/account/tickets")
@@ -23,25 +25,25 @@ public class TicketController {
     }
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public TicketResponse createTicket(
+    public ResponseEntity<TicketResponse> createTicket(
             @RequestBody TicketRequest request,
             @AuthenticationPrincipal OAuth2User user) {
 
         if (user == null || user.getAttribute("login") == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated");
+            return ResponseEntity.<TicketResponse>status(HttpStatus.UNAUTHORIZED).build();
         }
 
         String userId = user.getAttribute("login");
 
         Ticket newTicket = Ticket.create(userId, request.title(), request.description());
         Ticket savedTicket = ticketRepository.save(newTicket);
-        return new TicketResponse(
-                savedTicket.getId(),
-                savedTicket.getUserId(),
-                savedTicket.getTitle(),
-                savedTicket.getDescription()
-        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new TicketResponse(
+                        savedTicket.getId(),
+                        savedTicket.getUserId(),
+                        savedTicket.getTitle(),
+                        savedTicket.getDescription()
+                ));
     }
 
     @GetMapping

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -28,7 +28,12 @@ public class TicketController {
             @RequestBody TicketRequest request,
             @AuthenticationPrincipal OAuth2User user) {
 
-        String userId = user != null ? user.getAttribute("login") : "temp-user";
+        if (user == null || user.getAttribute("login") == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated");
+        }
+
+        String userId = user.getAttribute("login");
+
         Ticket newTicket = Ticket.create(userId, request.title(), request.description());
         Ticket savedTicket = ticketRepository.save(newTicket);
         return new TicketResponse(

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -42,17 +42,20 @@ class TicketControllerTest {
     @Test
     void should_create_ticket_and_return_201_created() throws Exception {
         TicketRequest request = new TicketRequest("Test Title", "Test description");
-        Ticket mockTicket = Ticket.create("testuser", request.title(), request.description());
+        Ticket mockTicket = Ticket.restore("ticket-123", "tester", request.title(), request.description());
+
         when(ticketRepository.save(any(Ticket.class))).thenReturn(mockTicket);
 
         mockMvc.perform(post("/api/account/tickets")
                         .with(csrf())
-                        .with(oauth2Login().attributes(attrs -> attrs.put("login", "testuser")))
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", "tester")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("ticket-123"))
+                .andExpect(jsonPath("$.userId").value("tester"))
                 .andExpect(jsonPath("$.title").value("Test Title"))
-                .andExpect(jsonPath("$.userId").value("testuser"));
+                .andExpect(jsonPath("$.description").value("Test description"));
         verify(ticketRepository).save(any(Ticket.class));
     }
 


### PR DESCRIPTION
### Description
This PR resolves the missing persistence and hardcoded response issue when creating a ticket (#768). The controller now correctly interacts with the repository layer, and the corresponding controller test has been updated for better predictability.

### Changes
Backend (Controller):
Replaced the hardcoded "temp-id" and response body with actual data returned from ticketRepository.save().
Utilized Ticket.create(userId, title, description) to properly encapsulate ticket initialization.

Backend (Test):
Updated should_create_ticket_and_return_201_created to use Ticket.restore() for deterministic ID assertions ("ticket-123"), eliminating randomness from UUIDs.
Cleansed redundant internal comments to ensure test code is clean and confident.

### Verification Results:

1. InMemoryTicketRepository integration verified.
2. MockMvc controller test passed successfully, covering:
3. HTTP 201 Created status
4. Proper interaction with TicketRepository.save()
5. Mock OAuth2 authentication context injection

Closes #768