### PR TITLE
feat(challenge): add ChallengeSolution Value Object

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeSolution.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeSolution.java
@@ -1,0 +1,15 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+
+public record ChallengeSolution(String value) {
+
+    public ChallengeSolution {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("The challenge solution must not be null, empty or blank.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeSolutionTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/domain/valueobject/ChallengeSolutionTest.java
@@ -1,0 +1,33 @@
+package com.itachallenges.challengeservice.catalog.domain.valueobject;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChallengeSolutionTest {
+
+    @Test
+    void should_create_solution_with_valid_value() {
+        ChallengeSolution solution = new ChallengeSolution("System.out.println();");
+        assertThat(solution.value()).isEqualTo("System.out.println();");
+    }
+
+    @Test
+    void should_throw_exception_when_solution_is_null() {
+        assertThatThrownBy(() -> new ChallengeSolution(null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_solution_is_empty() {
+        assertThatThrownBy(() -> new ChallengeSolution(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_solution_is_blank() {
+        assertThatThrownBy(() -> new ChallengeSolution("   "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Description
Added the `ChallengeSolution` Value Object to the domain layer along with its validation logic. The record ensures that a challenge solution cannot be created in an invalid state (null, empty, or blank).

## Changes
- `ChallengeSolution`: created the Value Object record with input validation.
- `ChallengeSolutionTest`: implemented unit tests for `ChallengeSolution`.