### PR TITLE
Feature/719 ChallengeLanguage dtos

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -24,14 +24,15 @@ public class ChallengeController {
     @PostMapping
     public ResponseEntity<ChallengeResponse> create(@RequestBody ChallengeRequest request) {
         Challenge saved = repository.save(
-                Challenge.create(request.title(), request.description(), ChallengeLanguage.JAVA)
+                Challenge.create(request.title(), request.description(), request.language())
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 new ChallengeResponse(
                         saved.getId().toString(),
                         saved.getTitle().toString(),
-                        saved.getDescription().toString()
+                        saved.getDescription().toString(),
+                        saved.getLanguage()
                 )
         );
     }
@@ -40,7 +41,7 @@ public class ChallengeController {
     public ResponseEntity<List<ChallengeResponse>> findAll() {
         List<ChallengeResponse> challenges = repository.findAll()
                 .stream()
-                .map(c -> new ChallengeResponse(c.getId().toString(), c.getTitle().toString(), c.getDescription().toString()))
+                .map(c -> new ChallengeResponse(c.getId().toString(), c.getTitle().toString(), c.getDescription().toString(), c.getLanguage()))
                 .toList();
         return ResponseEntity.ok(challenges);
     }
@@ -53,7 +54,9 @@ public class ChallengeController {
             ChallengeResponse challengeResponse =
                     new ChallengeResponse(challenge.getId().toString(),
                             challenge.getTitle().toString(),
-                            challenge.getDescription().toString());
+                            challenge.getDescription().toString(),
+                            challenge.getLanguage()
+                    );
             return ResponseEntity.ok(challengeResponse);
     }
 
@@ -82,7 +85,8 @@ public class ChallengeController {
         ChallengeResponse response = new ChallengeResponse(
                 updated.getId().toString(),
                 updated.getTitle().toString(),
-                updated.getDescription().toString()
+                updated.getDescription().toString(),
+                challenge.getLanguage()
         );
 
         return ResponseEntity.ok(response);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeRequest.java
@@ -1,3 +1,5 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto;
 
-public record ChallengeRequest(String title, String description) {}
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+
+public record ChallengeRequest(String title, String description, ChallengeLanguage language) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeResponse.java
@@ -1,4 +1,6 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto;
 
-public record ChallengeResponse (String id, String title, String description) {
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+
+public record ChallengeResponse (String id, String title, String description, ChallengeLanguage language) {
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -40,7 +40,8 @@ class ChallengeControllerTest {
 
     ChallengeRequest request = new ChallengeRequest(
             "Clean Code Challenge",
-            "A challenge about writing clean and maintainable code"
+            "A challenge about writing clean and maintainable code",
+            ChallengeLanguage.JAVA
     );
 
     @Test
@@ -63,7 +64,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.title").value("Clean Code Challenge"))
-                .andExpect(jsonPath("$.description").value("A challenge about writing clean and maintainable code"));
+                .andExpect(jsonPath("$.description").value("A challenge about writing clean and maintainable code"))
+                .andExpect(jsonPath("$.language").value("JAVA"));
     }
 
     @Test  void should_return_204_when_delete_challenge_by_id() throws Exception {
@@ -80,7 +82,8 @@ class ChallengeControllerTest {
         String id = UUID.randomUUID().toString();
         ChallengeRequest request = new ChallengeRequest(
                 "Updated title",
-                "Updated description"
+                "Updated description",
+                ChallengeLanguage.JAVA
         );
 
         Challenge updatedChallenge = Challenge.restore(
@@ -99,7 +102,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id))
                 .andExpect(jsonPath("$.title").value("Updated title"))
-                .andExpect(jsonPath("$.description").value("Updated description"));
+                .andExpect(jsonPath("$.description").value("Updated description"))
+                .andExpect(jsonPath("$.language").value("JAVA"));
     }
 
 
@@ -112,6 +116,7 @@ class ChallengeControllerTest {
         when(challenge.getId()).thenReturn(challengeId);
         when(challenge.getTitle()).thenReturn(new ChallengeTitle("Test Title"));
         when(challenge.getDescription()).thenReturn(new ChallengeDescription("Test Description"));
+        when(challenge.getLanguage()).thenReturn(ChallengeLanguage.JAVA);
 
         when(repository.find(challengeId)).thenReturn(challenge);
 
@@ -119,6 +124,7 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(uuid.toString()))
                 .andExpect(jsonPath("$.title").value("Test Title"))
-                .andExpect(jsonPath("$.description").value("Test Description"));
+                .andExpect(jsonPath("$.description").value("Test Description"))
+                .andExpect(jsonPath("$.language").value("JAVA"));
     }
 }


### PR DESCRIPTION
## Objective
This Pull Request implements the final phase of story **#719**. It updates the API contracts (DTOs) to receive and return the new `ChallengeLanguage` field, removing the temporary hardcoded values introduced during the Domain integration phase.

## Changes Made
- **DTOs (`ChallengeRequest`, `ChallengeResponse`):** Added the `language` attribute of type `ChallengeLanguage` to both input and output contracts.
- **Controller (`ChallengeController`):** Removed the temporary `ChallengeLanguage.JAVA` value, successfully connecting the incoming request language dynamically to the Domain creation process.
- **Tests (`ChallengeControllerTest`):** Updated unit tests and mocks. Added `jsonPath` assertions to guarantee the `language` field is properly parsed and returned in the HTTP responses.

## Related to:
Closes #719