### PR TITLE
Feat/776 ticket detail status select

### DIFF
--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -2,4 +2,11 @@
     <h1>{{ ticket.title}}</h1>
     <p>Usuari ID: {{ ticket.userId }}</p>
     <p>{{ ticket.description }}</p>
+
+    <select id="status">
+      <option value="" disabled>Selecciona l'estat</option>
+        @for (status of statusOptions; track $index) {
+          <option [value]="status.value">{{ status.label }}</option>
+        }
+    </select>
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -1,1 +1,5 @@
-<p>ticket-detail-page works!</p>
+@if (ticket) {
+    <h1>{{ ticket.title}}</h1>
+    <p>Usuari ID: {{ ticket.userId }}</p>
+    <p>{{ ticket.description }}</p>
+}

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -30,4 +30,13 @@ describe('TicketDetailPage', () => {
     expect(paragraphs[0]?.textContent).toContain(TICKETS_MOCK[0].userId);
     expect(paragraphs[1]?.textContent).toContain(TICKETS_MOCK[0].description);
   });
+
+  it('should render the status select with 3 options', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const selectElement = compiled.querySelector('select');
+    const options = compiled.querySelectorAll('select option');
+
+    expect(selectElement).toBeTruthy();
+    expect(options.length).toBe(4);
+  });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { TicketDetailPage } from './ticket-detail-page';
+import { TICKETS_MOCK } from '../../models/tickets.mock';
 
 describe('TicketDetailPage', () => {
   let component: TicketDetailPage;
@@ -19,5 +19,15 @@ describe('TicketDetailPage', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render ticket details in the HTML', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const titleElement = compiled.querySelector('h1');
+    const paragraphs = compiled.querySelectorAll('p');
+
+    expect(titleElement?.textContent).toContain(TICKETS_MOCK[0].title);
+    expect(paragraphs[0]?.textContent).toContain(TICKETS_MOCK[0].userId);
+    expect(paragraphs[1]?.textContent).toContain(TICKETS_MOCK[0].description);
   });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { ITicket } from '../../models/iticket.interface';
+import { TICKETS_MOCK } from '../../models/tickets.mock';
 
 @Component({
   selector: 'app-ticket-detail-page',
@@ -7,5 +9,7 @@ import { Component } from '@angular/core';
   styleUrl: './ticket-detail-page.css',
 })
 export class TicketDetailPage {
+
+  ticket: ITicket = TICKETS_MOCK[0];
 
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
@@ -11,5 +11,10 @@ import { TICKETS_MOCK } from '../../models/tickets.mock';
 export class TicketDetailPage {
 
   ticket: ITicket = TICKETS_MOCK[0];
+  statusOptions = [
+    { value: 'OPEN', label: 'Obert' },
+    { value: 'IN_PROGRESS', label: 'En progrés' },
+    { value: 'RESOLVED', label: 'Resolt' }
+  ];
 
 }

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
@@ -11,6 +11,7 @@ describe('TicketListPage', () => {
   let mockTicketApiService: Partial<TicketApiService>;
 
   beforeEach(async () => {
+    TestBed.resetTestingModule();
     mockTicketApiService = { loadAll: vi.fn().mockReturnValue(of(TICKETS_MOCK)) };
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/features/tickets/tickets.routes.ts
+++ b/frontend/src/app/features/tickets/tickets.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { TicketListPage } from './pages/ticket-list-page/ticket-list-page';
 import { CreateTicketPage } from './pages/create-ticket-page/create-ticket-page';
+import { TicketDetailPage } from './pages/ticket-detail-page/ticket-detail-page';
 
 export const TICKETS_ROUTES: Routes = [
   {
@@ -11,4 +12,8 @@ export const TICKETS_ROUTES: Routes = [
     path: 'create-ticket',
     component: CreateTicketPage,
   },
+  {
+    path: ':id',
+    component: TicketDetailPage,
+    },
 ];


### PR DESCRIPTION
#776 Task
### Description
Added a status dropdown selector with Catalan labels to the mock-based ticket detail page, along with structural unit tests.

**Note:** This PR includes trailing commits from the previous route setup branch. Once the base branch is merged into develop, this PR will automatically update to reflect only the selector changes.