### PR TITLE
Feat/734 auth   make the logout button fully log out the user

### DIFF
--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -78,13 +78,17 @@ describe('AuthService', () => {
     expect(result).toEqual(MOCK_USER);
   });
 
-  it('should clear current user on logout', () => {
-
+  it('should clear current user on logout', async () => {
     service.setUser(MOCK_USER);
 
-    service.logout();
+    const promise = firstValueFrom(service.logout());
+
+    const req = httpMock.expectOne('/api/account/auth/logout');
+    expect(req.request.method).toBe('POST');
+    req.flush('');
+
+    await promise;
 
     expect(service.user()).toBeNull();
-
   });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { Observable } from 'rxjs';
+import { map, Observable, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
 
@@ -11,6 +11,7 @@ export class AuthService {
 
   private readonly githubLoginUrl = '/api/account/oauth2/authorization/github';
   private readonly currentUserUrl = '/api/account/auth/me';
+  private readonly logoutUrl = '/api/account/auth/logout';
 
   user = signal<AuthUser | null>(null);
 
@@ -30,7 +31,12 @@ export class AuthService {
     return this.user();
   }
 
-  logout(): void {
-    this.user.set(null);
+  logout(): Observable<void> {
+    return this.http.post(this.logoutUrl, {}, { responseType: 'text' }).pipe(
+      tap(() => {
+        this.user.set(null);
+      }),
+      map(() => { })
+    );
   }
 }

--- a/frontend/src/app/shared/components/logout-button/logout-button.spec.ts
+++ b/frontend/src/app/shared/components/logout-button/logout-button.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LogoutButton } from './logout-button';
 import { AuthService } from '../../../features/auth/data-access/auth-service';
+import { of } from 'rxjs';
 
 describe('LogoutButton', () => {
 
@@ -15,7 +16,7 @@ describe('LogoutButton', () => {
   beforeEach(async () => {
 
     authServiceMock = {
-      logout: vi.fn(),
+      logout: vi.fn().mockReturnValue(of(void 0)),
     };
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/shared/components/logout-button/logout-button.ts
+++ b/frontend/src/app/shared/components/logout-button/logout-button.ts
@@ -12,7 +12,11 @@ export class LogoutButton {
   private authService = inject(AuthService);
 
   logout(): void {
-    this.authService.logout();
+    this.authService.logout().subscribe({
+      next: () => { },
+      error: (error) => {
+        console.error('Error crítico durante el proceso de logout:', error);
+      }
+    });
   }
-
 }

--- a/frontend/src/app/shared/components/logout-button/logout-button.ts
+++ b/frontend/src/app/shared/components/logout-button/logout-button.ts
@@ -14,7 +14,7 @@ export class LogoutButton {
   logout(): void {
     this.authService.logout().subscribe({
       error: (error) => {
-        console.error('Error durante el proceso de logout:', error);
+        console.error('Error durant el procés de logout:', error);
       }
     });
   }

--- a/frontend/src/app/shared/components/logout-button/logout-button.ts
+++ b/frontend/src/app/shared/components/logout-button/logout-button.ts
@@ -9,13 +9,12 @@ import { AuthService } from '../../../features/auth/data-access/auth-service';
 })
 export class LogoutButton {
 
-  private authService = inject(AuthService);
+  private readonly authService = inject(AuthService);
 
   logout(): void {
     this.authService.logout().subscribe({
-      next: () => { },
       error: (error) => {
-        console.error('Error crítico durante el proceso de logout:', error);
+        console.error('Error durante el proceso de logout:', error);
       }
     });
   }


### PR DESCRIPTION
**Description**

This PR resolves the incomplete logout behavior when clicking the logout button ([[#734](https://github.com/IT-Academy-BCN/ita-challenges/issues/734)]). The AuthService.logout() method now performs a real HTTP request to the backend and clears the user state reactively, and the corresponding tests have been updated to reflect this behavior.

**Changes**

Service: AuthService.logout() now performs a POST request to the logout endpoint and clears the user state reactively via tap(), returning Observable<void>.
Component: LogoutButton.logout() updated to subscribe to the observable and handle errors.
Tests: Updated specs for both AuthService and LogoutButton to reflect the new async behavior.

**Verification Results**

AuthService unit tests passed successfully, covering:

- User signal cleared after successful logout response
- HTTP POST request made to /api/account/auth/logout


LogoutButton component tests passed successfully, covering:

- Button click triggers logout() method
- AuthService.logout() is called



Closes [[#734](https://github.com/IT-Academy-BCN/ita-challenges/issues/734)]