### PR TITLE
feat(challenges): add delete button component structure (#741)

### DIFF
--- a/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.html
+++ b/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.html
@@ -1,0 +1,3 @@
+<button type="button" (click)="handleDelete()">
+    Delete
+</button>

--- a/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.spec.ts
+++ b/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DeleteButtonComponent } from './delete-button';
+
+describe('DeleteButtonComponent', () => {
+  let component: DeleteButtonComponent;
+  let fixture: ComponentFixture<DeleteButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeleteButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeleteButtonComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+  });
+
+  it('should emit delete event when button is clicked', () => {
+    const deleteSpy = vi.spyOn(component.deleteClick, 'emit');
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.ts
+++ b/frontend/src/app/features/challenges/components/buttons/delete-button/delete-button.ts
@@ -1,0 +1,16 @@
+import { Component, output } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-button',
+  standalone: true,
+  imports: [],
+  templateUrl: './delete-button.html',
+  styleUrl: './delete-button.css',
+})
+export class DeleteButtonComponent {
+  readonly deleteClick = output<void>();
+
+  handleDelete(): void {
+    this.deleteClick.emit();
+  }
+}


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/741)

## Summary
Introduced the base `DeleteButtonComponent` to handle challenge deletion interactions in a decoupled and reusable way.

The component is responsible only for emitting a click event, delegating the actual deletion logic to the parent component that manages the challenge list context.

This approach keeps the component UI-focused and improves reusability and separation of concerns.

## What's included
- Created `DeleteButtonComponent` in `challenges/components/buttons/delete-button/`
- Added component structure (`.ts`, `.html`, `.css`)
- Implemented `output()` event to emit delete action on click
- Added simple button UI with click handler
- Added unit test to verify event emission on click

> The component follows a “dumb component” pattern, emitting events without knowledge of domain data (such as challenge IDs), which are handled by the parent using the `@for` context.