### PR TITLE
"feat: add ChallengeDifficulty to Domain model"

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/model/Challenge.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/model/Challenge.java
@@ -1,6 +1,7 @@
 package com.itachallenges.challengeservice.catalog.domain.model;
 
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeTitle;
 import lombok.Getter;
@@ -11,26 +12,30 @@ public class Challenge {
     private final ChallengeId id;
     private final ChallengeTitle title;
     private final ChallengeDescription description;
+    private final ChallengeDifficulty difficulty;
 
-    private Challenge(ChallengeId id, ChallengeTitle title, ChallengeDescription description) {
+    private Challenge(ChallengeId id, ChallengeTitle title, ChallengeDescription description, ChallengeDifficulty difficulty) {
         this.id = id;
         this.title = title;
         this.description = description;
+        this.difficulty = difficulty;
     }
 
-    public static Challenge create(String title, String description) {
+    public static Challenge create(String title, String description, ChallengeDifficulty difficulty) {
         return new Challenge(
                 ChallengeId.generate(),
                 new ChallengeTitle(title),
-                new ChallengeDescription(description)
+                new ChallengeDescription(description),
+                difficulty
         );
     }
 
-    public static Challenge restore(ChallengeId id, String title, String description) {
+    public static Challenge restore(ChallengeId id, String title, String description, ChallengeDifficulty difficulty) {
         return new Challenge(
                 id,
                 new ChallengeTitle(title),
-                new ChallengeDescription(description)
+                new ChallengeDescription(description),
+                difficulty
         );
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeResponse;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
@@ -23,7 +24,7 @@ public class ChallengeController {
     @PostMapping
     public ResponseEntity<ChallengeResponse> create(@RequestBody ChallengeRequest request) {
         Challenge saved = repository.save(
-                Challenge.create(request.title(), request.description())
+                Challenge.create(request.title(), request.description(), ChallengeDifficulty.EASY)
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
@@ -73,7 +74,8 @@ public class ChallengeController {
         Challenge challenge = Challenge.restore(
                 new ChallengeId(UUID.fromString(id)),
                 request.title(),
-                request.description()
+                request.description(),
+                ChallengeDifficulty.EASY
         );
 
         Challenge updated = repository.update(challenge);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
@@ -87,7 +88,8 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
                         Challenge.restore(
                                 ChallengeId.of(r.id()),
                                 r.title(),
-                                r.description())));
+                                r.description(),
+                                ChallengeDifficulty.EASY)));
     }
 
     record ChallengeRecord(String id, String title, String description) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -32,7 +33,8 @@ public class ChallengeSeedLoader implements ApplicationRunner {
                     .map(seed -> Challenge.restore(
                             ChallengeId.of(seed.id()),
                             seed.title(),
-                            seed.description()
+                            seed.description(),
+                            ChallengeDifficulty.EASY
                     ))
                     .forEach(repository::save);
         }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class InMemoryChallengeRepositoryTest {
     @BeforeEach
     void setUp() {
         repository = new InMemoryChallengeRepository();
-        challenge = Challenge.create("Clean Code Challenge", "A challenge about writing clean and maintainable code");
+        challenge = Challenge.create("Clean Code Challenge", "A challenge about writing clean and maintainable code", ChallengeDifficulty.EASY);
     }
 
     @Test
@@ -30,7 +31,7 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_create_new_challenge() {
-        Challenge newChallenge = Challenge.create("New Challenge Title", "New Challenge Description");
+        Challenge newChallenge = Challenge.create("New Challenge Title", "New Challenge Description", ChallengeDifficulty.EASY);
         Challenge result = repository.save(newChallenge);
 
         assertThat(result.getTitle().toString()).isEqualTo("New Challenge Title");
@@ -39,12 +40,13 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_update_existing_challenge() {
-        Challenge original = repository.save(Challenge.create("Old title", "Old description"));
+        Challenge original = repository.save(Challenge.create("Old title", "Old description", ChallengeDifficulty.EASY));
 
         Challenge updated = Challenge.restore(
                 original.getId(),
                 "New title",
-                "New description"
+                "New description",
+                ChallengeDifficulty.EASY
         );
 
         Challenge result = repository.update(updated);
@@ -57,7 +59,7 @@ class InMemoryChallengeRepositoryTest {
 
     @Test
     void should_delete_existing_challenge() {
-        Challenge challenge = Challenge.create("To be deleted", "Description");
+        Challenge challenge = Challenge.create("To be deleted", "Description", ChallengeDifficulty.EASY);
 
         ChallengeId id = challenge.getId();
         repository.save(challenge);

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.ou
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ class JsonFileChallengeRepositoryTest {
 
         Challenge challenge = Challenge.create(
                 "Clean Code",
-                "Write readable code"
+                "Write readable code",
+                ChallengeDifficulty.EASY
         );
 
         repository.save(challenge);

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDescription;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeTitle;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller.ChallengeController;
@@ -53,7 +54,7 @@ class ChallengeControllerTest {
 
     @Test
     void should_create_challenge_with_title_and_description_and_return_201() throws Exception {
-        Challenge saved = Challenge.create(request.title(), request.description());
+        Challenge saved = Challenge.create(request.title(), request.description(), ChallengeDifficulty.EASY);
         when(repository.save(any(Challenge.class))).thenReturn(saved);
 
         mockMvc.perform(post("/api/challenge")
@@ -85,7 +86,8 @@ class ChallengeControllerTest {
         Challenge updatedChallenge = Challenge.restore(
                 new ChallengeId(UUID.fromString(id)),
                 "Updated title",
-                "Updated description"
+                "Updated description",
+                ChallengeDifficulty.EASY
         );
 
         when(repository.update(any(Challenge.class)))


### PR DESCRIPTION
## PR Objective
This Pull Request implements the first phase (Domain) of story **#720**. The difficulty level has been introduced into the application's core model, paving the way for the upcoming update to the DTOs.

## Changes Made
- **Domain (`Challenge.java`):** Added the immutable attribute `difficulty` of type `ChallengeDifficulty`.
- **Constructors and Methods:** Updated the `create` and `restore` methods to require the difficulty when creating/restoring the entity.
- **Controllers and Tests:** Applied the temporary value `ChallengeDifficulty.EASY` in the `ChallengeController` and across the test suite to ensure the project compiles successfully while waiting for the DTO phase.

## Related to:
Part of #720