### PR TITLE
Feature/720 ChallengeDifficulty dtos

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -24,14 +24,15 @@ public class ChallengeController {
     @PostMapping
     public ResponseEntity<ChallengeResponse> create(@RequestBody ChallengeRequest request) {
         Challenge saved = repository.save(
-                Challenge.create(request.title(), request.description(), ChallengeDifficulty.EASY)
+                Challenge.create(request.title(), request.description(), request.difficulty())
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 new ChallengeResponse(
                         saved.getId().toString(),
                         saved.getTitle().toString(),
-                        saved.getDescription().toString()
+                        saved.getDescription().toString(),
+                        saved.getDifficulty()
                 )
         );
     }
@@ -40,7 +41,7 @@ public class ChallengeController {
     public ResponseEntity<List<ChallengeResponse>> findAll() {
         List<ChallengeResponse> challenges = repository.findAll()
                 .stream()
-                .map(c -> new ChallengeResponse(c.getId().toString(), c.getTitle().toString(), c.getDescription().toString()))
+                .map(c -> new ChallengeResponse(c.getId().toString(), c.getTitle().toString(), c.getDescription().toString(), c.getDifficulty()))
                 .toList();
         return ResponseEntity.ok(challenges);
     }
@@ -53,7 +54,8 @@ public class ChallengeController {
             ChallengeResponse challengeResponse =
                     new ChallengeResponse(challenge.getId().toString(),
                             challenge.getTitle().toString(),
-                            challenge.getDescription().toString());
+                            challenge.getDescription().toString(),
+                            challenge.getDifficulty());
             return ResponseEntity.ok(challengeResponse);
     }
 
@@ -82,7 +84,8 @@ public class ChallengeController {
         ChallengeResponse response = new ChallengeResponse(
                 updated.getId().toString(),
                 updated.getTitle().toString(),
-                updated.getDescription().toString()
+                updated.getDescription().toString(),
+                updated.getDifficulty()
         );
 
         return ResponseEntity.ok(response);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -77,7 +77,7 @@ public class ChallengeController {
                 new ChallengeId(UUID.fromString(id)),
                 request.title(),
                 request.description(),
-                ChallengeDifficulty.EASY
+                request.difficulty()
         );
 
         Challenge updated = repository.update(challenge);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeRequest.java
@@ -1,3 +1,5 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto;
 
-public record ChallengeRequest(String title, String description) {}
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
+
+public record ChallengeRequest(String title, String description, ChallengeDifficulty difficulty) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/dto/ChallengeResponse.java
@@ -1,4 +1,6 @@
 package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto;
 
-public record ChallengeResponse (String id, String title, String description) {
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
+
+public record ChallengeResponse (String id, String title, String description, ChallengeDifficulty difficulty) {
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -74,11 +74,11 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
     private void persistToFile() throws IOException {
         objectMapper.writeValue(storageFile, storage.values().stream()
                 .map(c -> new ChallengeRecord(
-                                        c.getId().toString(),
-                                        c.getTitle().toString(),
-                                        c.getDescription().toString(),
-                                        c.getLanguage().toString(),
-                                        c.getDifficulty().toString()
+                                            c.getId().toString(),
+                                            c.getTitle().toString(),
+                                            c.getDescription().toString(),
+                                            c.getLanguage().toString(),
+                                            c.getDifficulty().toString()
                 )).toList());
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -75,7 +75,8 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
                 .map(c -> new ChallengeRecord(
                         c.getId().toString(),
                         c.getTitle().toString(),
-                        c.getDescription().toString()))
+                        c.getDescription().toString(),
+                        c.getDifficulty().toString()))
                 .toList());
     }
 
@@ -89,8 +90,8 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
                                 ChallengeId.of(r.id()),
                                 r.title(),
                                 r.description(),
-                                ChallengeDifficulty.EASY)));
+                                ChallengeDifficulty.valueOf(r.difficulty()))));
     }
 
-    record ChallengeRecord(String id, String title, String description) {}
+    record ChallengeRecord(String id, String title, String description, String difficulty) {}
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/seed/ChallengeSeedLoader.java
@@ -34,11 +34,11 @@ public class ChallengeSeedLoader implements ApplicationRunner {
                             ChallengeId.of(seed.id()),
                             seed.title(),
                             seed.description(),
-                            ChallengeDifficulty.EASY
+                            seed.difficulty()
                     ))
                     .forEach(repository::save);
         }
     }
 
-    private record ChallengeSeed(String id, String title, String description) {}
+    private record ChallengeSeed(String id, String title, String description, ChallengeDifficulty difficulty) {}
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -40,7 +40,8 @@ class ChallengeControllerTest {
 
     ChallengeRequest request = new ChallengeRequest(
             "Clean Code Challenge",
-            "A challenge about writing clean and maintainable code"
+            "A challenge about writing clean and maintainable code",
+            ChallengeDifficulty.EASY
     );
 
     @Test
@@ -63,7 +64,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").isNotEmpty())
                 .andExpect(jsonPath("$.title").value("Clean Code Challenge"))
-                .andExpect(jsonPath("$.description").value("A challenge about writing clean and maintainable code"));
+                .andExpect(jsonPath("$.description").value("A challenge about writing clean and maintainable code"))
+                .andExpect(jsonPath("$.difficulty").value("EASY"));
     }
 
     @Test  void should_return_204_when_delete_challenge_by_id() throws Exception {
@@ -80,7 +82,8 @@ class ChallengeControllerTest {
         String id = UUID.randomUUID().toString();
         ChallengeRequest request = new ChallengeRequest(
                 "Updated title",
-                "Updated description"
+                "Updated description",
+                ChallengeDifficulty.EASY
         );
 
         Challenge updatedChallenge = Challenge.restore(
@@ -99,7 +102,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id))
                 .andExpect(jsonPath("$.title").value("Updated title"))
-                .andExpect(jsonPath("$.description").value("Updated description"));
+                .andExpect(jsonPath("$.description").value("Updated description"))
+                .andExpect(jsonPath("$.difficulty").value("EASY"));
     }
 
 
@@ -112,6 +116,7 @@ class ChallengeControllerTest {
         when(challenge.getId()).thenReturn(challengeId);
         when(challenge.getTitle()).thenReturn(new ChallengeTitle("Test Title"));
         when(challenge.getDescription()).thenReturn(new ChallengeDescription("Test Description"));
+        when(challenge.getDifficulty()).thenReturn(ChallengeDifficulty.EASY);
 
         when(repository.find(challengeId)).thenReturn(challenge);
 
@@ -119,6 +124,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(uuid.toString()))
                 .andExpect(jsonPath("$.title").value("Test Title"))
-                .andExpect(jsonPath("$.description").value("Test Description"));
+                .andExpect(jsonPath("$.description").value("Test Description"))
+                .andExpect(jsonPath("$.difficulty").value("EASY"));
+
     }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -43,7 +43,7 @@ class ChallengeControllerTest {
                 "Clean Code Challenge",
                 "A challenge about writing clean and maintainable code",
                 ChallengeLanguage.JAVA,
-                ChallengeDifficulty.EASY
+                ChallengeDifficulty.MEDIUM
         );
 
     @Test
@@ -87,7 +87,7 @@ class ChallengeControllerTest {
                 "Updated title",
                 "Updated description",
                 ChallengeLanguage.JAVA,
-                ChallengeDifficulty.EASY
+                ChallengeDifficulty.HARD
                 );
 
         Challenge updatedChallenge = Challenge.restore(


### PR DESCRIPTION
## PR Objective
This Pull Request implements the final phase (DTOs and Web Layer) of story **#720**. It fully integrates the `ChallengeDifficulty` level from the domain down to the REST API, allowing clients to send and receive the difficulty when creating or fetching challenges.

## Changes Made
- **DTOs (`ChallengeRequest` & `ChallengeResponse`):** Added the `difficulty` field.
- **Web Layer (`ChallengeController`):** Removed the temporary domain patches and fully wired the incoming request data to the Domain model.
- **Tests (`ChallengeControllerTest`):** Updated constructors and assertions to ensure the difficulty is properly mapped in the JSON responses.

## Note for Reviewers
This branch was created from the Domain phase branch. Once the Domain PR is merged, the diff here will automatically update to show only the DTO and Controller changes.

## Related to:
Closes #720