### PR TITLE
test(challenge): fix challenge submission endpoint spec

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -143,19 +143,19 @@ describe('ChallengeApiService', () => {
   });
 
   describe('postSolution', () => {
-  it('should call POST with correct URL and payload', () => {
-    const payload: IChallengeSubmission = {
-      challengeId: 'abc-123',
-      userId: 'abc-345',
-      code: 'code'
-    };
+    it('should call POST with correct URL and payload', () => {
+      const payload: IChallengeSubmission = {
+        challengeId: 'abc-123',
+        userId: 'abc-345',
+        code: 'code'
+      };
 
-    service.postSolution(payload).subscribe();
+      service.postSolution(payload).subscribe();
 
-    const req = httpTestingController.expectOne(`${apiUrl}/submissions/finalize`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual(payload);
-    req.flush(null);
+      const req = httpTestingController.expectOne(`${apiUrl}/submissions`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(payload);
+      req.flush(null);
+    });
   });
-});
 });


### PR DESCRIPTION

## Summary

Updated the `ChallengeApiService` unit test to reflect the current submission endpoint implementation.

The test was still expecting requests to the deprecated `/submissions/finalize` route, while the service now sends submissions directly to `/submissions`.

## What's included

* Updated `postSolution` spec endpoint expectation
* Replaced `/submissions/finalize` with `/submissions`
* Verified POST request payload assertion remains unchanged
* Fixed failing unit test caused by outdated endpoint expectation

> This change only affects the test suite and keeps it aligned with the current API implementation.