### PR TITLE
feat: Get user role by username.

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,7 +1,7 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
 import com.ita.challenges.account.domain.port.out.UserRepository;
-import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserResponse;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserRoleResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,10 +18,10 @@ public class UserController {
         this.userRepository = userRepository;
     }
 
-    @GetMapping("/{username}")
-    public ResponseEntity<UserResponse> getUserRole(@PathVariable String username) {
+    @GetMapping("/{username}/role")
+    public ResponseEntity<UserRoleResponse> getUserRole(@PathVariable String username) {
         return userRepository.findByUsername(username)
-                .map(user -> ResponseEntity.ok(new UserResponse(user.userName(), user.userRole())))
+                .map(user -> ResponseEntity.ok(new UserRoleResponse(user.userRole())))
                 .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,9 +1,27 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.ita.challenges.account.domain.port.out.UserRepository;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/account/users")
 public class UserController {
+
+    private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/{username}")
+    public ResponseEntity<UserResponse> getUserRole(@PathVariable String username) {
+        return userRepository.findByUsername(username)
+                .map(user -> ResponseEntity.ok(new UserResponse(user.userName(), user.userRole())))
+                .orElse(ResponseEntity.notFound().build());
+    }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/UserRoleResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/UserRoleResponse.java
@@ -1,0 +1,5 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
+
+import com.ita.challenges.account.domain.model.Role;
+
+public record UserRoleResponse(Role role) {}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -1,7 +1,52 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.ita.challenges.account.domain.model.Role;
+import com.ita.challenges.account.domain.model.User;
+import com.ita.challenges.account.domain.port.out.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
 class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    @Test
+    @WithMockUser
+    void shouldReturnUserRoleWhenUserExists() throws Exception {
+        User user = new User("testuser", Role.STUDENT);
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/account/users/testuser"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("testuser"))
+                .andExpect(jsonPath("$.role").value("STUDENT"));
+    }
+
+    @Test
+    @WithMockUser
+    void shouldReturn404WhenUserNotFound() throws Exception {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/account/users/unknown"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -35,9 +35,8 @@ class UserControllerTest {
         User user = new User("testuser", Role.STUDENT);
         when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
 
-        mockMvc.perform(get("/api/account/users/testuser"))
+        mockMvc.perform(get("/api/account/users/testuser/role"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.username").value("testuser"))
                 .andExpect(jsonPath("$.role").value("STUDENT"));
     }
 
@@ -46,7 +45,7 @@ class UserControllerTest {
     void shouldReturn404WhenUserNotFound() throws Exception {
         when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/account/users/unknown"))
+        mockMvc.perform(get("/api/account/users/unknown/role"))
                 .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
Added a GET endpoint to retrieve the username and role of a user by their GitHub username.
This allows the frontend to display the user's role in the header.

Changes:
- Added GET /api/account/users/{username} endpoint in UserController
- Returns username and role in the response
- Returns 404 if the user is not found
- Added unit tests for both cases

Closes #730 