### PR TITLE
Feat/782 ticket detail comment textarea

### DIFF
--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -9,4 +9,8 @@
           <option [value]="status.value">{{ status.label }}</option>
         }
     </select>
+    <div>
+      <label for="comment">Comentari del Mentor:</label><br>
+      <textarea id="comment" rows="10"></textarea>
+    </div>
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -39,4 +39,12 @@ describe('TicketDetailPage', () => {
     expect(selectElement).toBeTruthy();
     expect(options.length).toBe(4);
   });
+
+  it('should render the comment textarea', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const textareaElement = compiled.querySelector('textarea');
+    expect(textareaElement).toBeTruthy();
+    expect(textareaElement?.getAttribute('id')).toBe('comment');
+    expect(textareaElement?.getAttribute('rows')).toBe('10');
+  });
 });


### PR DESCRIPTION
#782 
### Description
Added a textarea element for mentor feedback to the ticket detail page, along with corresponding layout markup and structural unit tests.

**Note:** This PR builds upon the previous selector branch. Once the base branch (feature/ticket-detail-status) is merged, this PR will automatically update to isolate only the comment field changes.