### PR TITLE
feat(Tickecting) Unified PATCH Request DTO for Ticket Status and Comment

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketPatchRequest.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketPatchRequest.java
@@ -1,0 +1,8 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
+
+import com.ita.challenges.account.domain.model.TicketStatus;
+
+public record TicketPatchRequest(
+    TicketStatus status,
+    String comment
+) {}


### PR DESCRIPTION
### [TICKETING] Unified PATCH Request DTO for Ticket Status and Comment (#794)

**What?**
Create a unified request object (`TicketPatchRequest`) carrying both the comment text and the ticket status from the frontend to the backend.

**Why?**
To allow a single PATCH endpoint to update tickets consistently. By including both fields in one DTO, the backend can process comments and status changes together, which prevents duplicated logic and keeps the frontend aligned with backend expectations.

**Behaviour expected**
- When updating a ticket, the PATCH request may include `status`, `comment`, or both.
- Both fields are optional in the payload, allowing partial ticket updates.
- The backend must handle requests whether one or both fields are present, updating only the supplied values.