### PR TITLE
feat(auth): display username in header #732

### DIFF
--- a/frontend/src/app/layout/components/header/header.html
+++ b/frontend/src/app/layout/components/header/header.html
@@ -2,8 +2,12 @@
   <h1>IT ACADEMY</h1>
 
   @if (user()) {
+    <h4 >
+      {{ user()?.username }}
+    </h4>
+
     <div class="user__profile">
-        <img [src]="user()?.avatarUrl" alt="avatar" class="avatar__image"/>
+      <img [src]="user()?.avatarUrl" alt="avatar" class="avatar__image"/>
     </div>
   }
 

--- a/frontend/src/app/layout/components/header/header.spec.ts
+++ b/frontend/src/app/layout/components/header/header.spec.ts
@@ -56,6 +56,22 @@ describe('Header', () => {
 
   });
 
+  it('should show username when user is logged in', () => {
+    authServiceMock.user.set(MOCK_USER);
+    fixture.detectChanges();
+
+    const h4 = fixture.nativeElement.querySelector('h4');
+    expect(h4.textContent).toContain(MOCK_USER.username);
+  });
+
+  it('should not show username when user is not logged in', () => {
+    authServiceMock.user.set(null);
+    fixture.detectChanges();
+
+    const h4 = fixture.nativeElement.querySelector('h4');
+    expect(h4).toBeFalsy();
+  });
+
   it('should show user avatar when user is logged in', () => {
     authServiceMock.user.set(MOCK_USER);
     fixture.detectChanges();


### PR DESCRIPTION
### **Show the logged-in user's name in the header**

**Description:**

When a user is logged in, their username is now displayed in the header of the application. This way, users can easily see at a glance which account they are currently using, improving the overall experience and making the interface feel more personal.