### PR TITLE
feat(challenges): show language and difficulty in challenge detail page (#864)

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -1,7 +1,9 @@
-
-@if (challenge()) {
-  <h1>{{ challenge()?.title }}</h1>
-  <p>{{ challenge()?.description}}</p>
+@if (challenge(); as ch) {
+  <h1>{{ ch.title }}</h1>
+  <p>{{ ch.description }}</p>
+  <p>Dificultat: {{ getDifficultyLabel(ch.difficulty) }}</p>
+  <p>Llenguatge: {{ getLanguageLabel(ch.language) }}</p>
+    
   <form [formGroup]="codeSolutionForm" (ngSubmit)="saveSolution()">
     <textarea
         id="challengeAnswer"

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -25,7 +25,7 @@ describe('ChallengeDetailPage', () => {
   beforeEach(async () => {
     mockChallengeService = { getById: vi.fn().mockReturnValue(of(mockChallenge)) };
     mockActivatedRoute = { snapshot: { paramMap: { get: vi.fn().mockReturnValue('test-123') } } };
-    mockChallengeApiService = {postSolution: vi.fn().mockReturnValue(of({}))};
+    mockChallengeApiService = { saveSolution: vi.fn().mockReturnValue(of({}))};
     mockAuthService = {user: vi.fn().mockReturnValue({ id: 'user-456' })};
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -18,6 +18,8 @@ describe('ChallengeDetailPage', () => {
     id: 'test-123',
     title: 'Test Challenge',
     description: 'Test Description',
+    language: 'JAVASCRIPT',
+    difficulty: 'EASY',
   };
 
   beforeEach(async () => {
@@ -67,5 +69,17 @@ describe('ChallengeDetailPage', () => {
       userId: 'user-456',
       code: 'my-code'
     });
+  });
+
+  it('should display language and difficulty in template', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('Test Challenge');
+    expect(element.textContent).toContain('Test Description');
+    expect(element.textContent).toContain('Llenguatge');
+    expect(element.textContent).toContain('Dificultat');
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -7,6 +7,8 @@ import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ChallengeApiService } from '../../data-access/challenge-api.service';
 import { AuthService } from '../../../auth/data-access/auth-service';
 import { IChallengeSubmission } from '../../models/ichallenge-submission.interface';
+import { ChallengeLanguage } from '../../models/challenge-language.type';
+import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 
 interface AuthUserWithId extends AuthUser {
   id: string;
@@ -27,12 +29,35 @@ export class ChallengeDetailPage {
 
   challenge = signal<IChallenge | undefined>(undefined);
 
+  languageLabels: Record<ChallengeLanguage, string> = {
+    JAVA: 'Java',
+    PHP: 'PHP',
+    JAVASCRIPT: 'JavaScript',
+    TYPESCRIPT: 'TypeScript',
+    PYTHON: 'Python',
+    SQL: 'SQL',
+  };
+
+  difficultyLabels: Record<ChallengeDifficulty, string> = {
+    EASY: 'Fàcil',
+    MEDIUM: 'Mitjana',
+    HARD: 'Difícil',
+  };
+
   ngOnInit() {
     const id = this.route.snapshot.paramMap.get('id')!;
 
     this.challengesService.getById(id).subscribe((selectedChallenge) => {
       this.challenge.set(selectedChallenge);
     });
+  }
+
+  getLanguageLabel(lang?: ChallengeLanguage): string {
+    return lang ? this.languageLabels[lang] : '';
+  }
+
+  getDifficultyLabel(diff?: ChallengeDifficulty): string {
+    return diff ? this.difficultyLabels[diff] : '';
   }
 
   codeSolutionForm = this.fb.group({


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/864)

## Summary
Added `language` and `difficulty` display to the `challenge-detail-page`, allowing users to see structured metadata for each challenge.

This improves the clarity of challenge information without modifying existing domain logic or breaking current functionality.

## What's included
- Displayed `ChallengeLanguage` in the challenge detail page
- Displayed `ChallengeDifficulty` in the challenge detail page
- Added label mapping for `language` values (e.g. JAVASCRIPT → JavaScript)
- Added label mapping for `difficulty` values (EASY → Fàcil, etc.)
- Updated unit tests to verify UI rendering of new fields

> This change is purely presentational and does not affect backend data or domain models.