### PR TITLE
feat(challenges): add delete button to challenges list page (#743)

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.css
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.css
@@ -4,3 +4,8 @@
     justify-content: space-between;
     align-items: center;
 }
+
+.challenges-list__actions {
+    display: flex;
+    gap: 1rem;
+}

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -12,11 +12,19 @@
 
 @if (challenges().length > 0) {
     <ul>
-        @for (challenge of challenges(); track $index) {
+        @for (challenge of challenges(); track challenge.id) {
         <li>
             <h2>{{ challenge.title }}</h2>
             <p>{{ challenge.description }}</p>
-            <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
+
+            <div class="challenges-list__actions">
+                <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
+                @if(isMentor()) {
+                    <app-delete-button
+                        (deleteClick)="handleDelete(challenge.id)">
+                    </app-delete-button>
+                }
+            </div>
         </li>
         }
     </ul>

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -15,7 +15,10 @@ describe('ChallengesListPage', () => {
   let mockChallengeService: any;
 
   beforeEach(async () => {
-    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK))};
+    mockChallengeService = { 
+      loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK)),
+      delete: vi.fn().mockReturnValue(of(void 0)),
+    };
 
     await TestBed.configureTestingModule({
       imports: [ChallengesListPage],
@@ -77,5 +80,15 @@ describe('ChallengesListPage', () => {
 
     component.onRoleChange(false);
     expect(component.isMentor()).toBe(false);
+  });
+
+  it('should delete a challenge and remove it from the list', () => {
+    const initialLength = component.challenges().length;
+
+    component.handleDelete(CHALLENGES_MOCK[0].id);
+
+    expect(mockChallengeService.delete).toHaveBeenCalledWith(CHALLENGES_MOCK[0].id);
+    expect(component.challenges().length).toBe(initialLength - 1);
+    expect(component.challenges().some(c => c.id === CHALLENGES_MOCK[0].id)).toBe(false);
   });
 });

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -48,6 +48,9 @@ export class ChallengesListPage implements OnInit {
         this.challenges.update((current) =>
           current.filter((challenge) => challenge.id !== id)
         );
+      },
+      error: (err) => {
+        console.error('Error deleting challenge', err);
       }
     });
   }

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,13 +1,20 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
+import { RouterLink } from "@angular/router";
+
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
 import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
-import { RouterLink } from "@angular/router";
+import { DeleteButtonComponent } from "../../components/buttons/delete-button/delete-button";
 
 @Component({
   selector: 'app-challenges-list-page',
-  imports: [CreateButtonComponent, RoleSelectorComponent, RouterLink],
+  imports: [
+    RouterLink, 
+    RoleSelectorComponent, 
+    CreateButtonComponent, 
+    DeleteButtonComponent
+  ],
   standalone: true,
   templateUrl: './challenges-list-page.html',
   styleUrl: './challenges-list-page.css',
@@ -34,4 +41,15 @@ export class ChallengesListPage implements OnInit {
   onRoleChange(value: boolean): void {
     this.isMentor.set(value);
   }
+
+  handleDelete(id: string): void {
+    this.challengesService.delete(id).subscribe({
+      next: () => {
+        this.challenges.update((current) =>
+          current.filter((challenge) => challenge.id !== id)
+        );
+      }
+    });
+  }
+
 }


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/743)

## Summary
Integrated the `DeleteButtonComponent` into the challenges list page, allowing mentors to delete challenges directly from the list without navigating to the detail view.

This update adds the delete action to the existing role-based UI, ensuring that only mentor users can access destructive actions such as deletion.

## What's included
- Integrated `DeleteButtonComponent` inside the challenges list page
- Added delete action inside existing role-based actions section
  - Delete button is only visible for mentor users
- Added `handleDelete` method usage to trigger challenge deletion