### PR TITLE
Feat/776 ticket form update status

### DIFF
--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -3,12 +3,14 @@
     <p>Usuari ID: {{ t.userId }}</p>
     <p>{{ t.description }}</p>
 
-    <select id="status">
-      <option value="" disabled>Selecciona l'estat</option>
-        @for (status of statusOptions; track $index) {
-          <option [value]="status.value" [selected]="status.value === t.status">
-            {{ status.label }}
-          </option>
-        }
-    </select>
+    <form [formGroup]="ticketForm" (ngSubmit)="onSubmit()">
+      <select id="status" formControlName="status">
+        <option value="" disabled>Selecciona l'estat</option>
+          @for (status of statusOptions; track $index) {
+            <option [value]="status.value">{{ status.label }}</option>
+          }
+      </select>
+
+      <button type="submit">Guardar</button>
+    </form>
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -4,6 +4,7 @@ import { TICKETS_MOCK } from '../../models/tickets.mock';
 import { TicketService } from '../../ticket.service';
 import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
+import { TicketApiService } from '../../data-access/ticket-api.service';
 
 describe('TicketDetailPage', () => {
   let component: TicketDetailPage;
@@ -17,6 +18,10 @@ describe('TicketDetailPage', () => {
         {
           provide: TicketService,
           useValue: { getById: () => of(mockTicket) }
+        },
+        {
+          provide: TicketApiService,
+          useValue: { update: () => of(mockTicket) }
         },
         {
           provide: ActivatedRoute,
@@ -53,5 +58,20 @@ describe('TicketDetailPage', () => {
 
     expect(selectElement).toBeTruthy();
     expect(options.length).toBe(4);
+  });
+
+  it('should preselect the status from the ticket', () => {
+    expect(component.ticketForm.value.status).toBe(mockTicket.status);
+  });
+
+  it('should call update on submit', () => {
+    const ticketApiService = TestBed.inject(TicketApiService);
+    vi.spyOn(ticketApiService, 'update').mockReturnValue(of(mockTicket));
+
+    component.onSubmit();
+
+    expect(ticketApiService.update).toHaveBeenCalledWith(mockTicket.id, {
+      status: mockTicket.status
+    });
   });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
@@ -2,17 +2,21 @@ import { Component, inject, signal } from '@angular/core';
 import { ITicket } from '../../models/iticket.interface';
 import { TicketService } from '../../ticket.service';
 import { ActivatedRoute } from '@angular/router';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { TicketApiService } from '../../data-access/ticket-api.service';
 
 @Component({
   selector: 'app-ticket-detail-page',
-  imports: [],
+  imports: [ReactiveFormsModule],
   templateUrl: './ticket-detail-page.html',
   styleUrl: './ticket-detail-page.css',
 })
 export class TicketDetailPage {
 
   private readonly ticketService = inject(TicketService)
+  private readonly ticketApiService = inject(TicketApiService)
   private readonly route = inject(ActivatedRoute)
+  private readonly fb = inject(FormBuilder)
   ticket = signal<ITicket | undefined>(undefined)
 
 
@@ -21,6 +25,7 @@ export class TicketDetailPage {
 
     this.ticketService.getById(id).subscribe((selectedTicket) => {
       this.ticket.set(selectedTicket);
+      this.ticketForm.patchValue({ status: selectedTicket?.status });
     });
   }
 
@@ -29,5 +34,25 @@ export class TicketDetailPage {
     { value: 'IN_PROGRESS', label: 'En progrés' },
     { value: 'RESOLVED', label: 'Resolt' }
   ];
+
+  ticketForm = this.fb.group({
+      status: ['' as ITicket['status']]
+    })
+
+  onSubmit() : void {
+    const currentTicket = this.ticket();
+
+    if (this.ticketForm.valid && currentTicket?.id) {
+      const ticketUpdate = {
+        status: this.ticketForm.value.status ?? undefined
+        };
+
+      this.ticketApiService.update(currentTicket.id, ticketUpdate).subscribe({
+      next: () => {
+        alert('Canvi guardat!');
+      }
+    });
+    }
+  }
 
 }


### PR DESCRIPTION
#776 Task
**Description:** Add reactive form to update ticket status from the detail page.

- Initialize select with current status from the API
- Call update() on submit to persist the change
- Add unit tests for form initialization and submit

Note: This PR is created from a previous PR, once the other PR is merged, it will be shorter.