### PR TITLE
Feat/782 ticket form update comment

### DIFF
--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -11,6 +11,11 @@
           }
       </select>
 
+      <div>
+      <label for="comment">Afegir comentari:</label><br>
+      <textarea id="comment" rows="10" formControlName="comment"></textarea>
+    </div>
+
       <button type="submit">Guardar</button>
     </form>
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -51,7 +51,7 @@ describe('TicketDetailPage', () => {
     expect(paragraphs[1]?.textContent).toContain(mockTicket.description);
   });
 
-  it('should render the status select with 3 options', () => {
+  it('should render the status select with 4 options', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const selectElement = compiled.querySelector('select');
     const options = compiled.querySelectorAll('select option');
@@ -67,11 +67,12 @@ describe('TicketDetailPage', () => {
   it('should call update on submit', () => {
     const ticketApiService = TestBed.inject(TicketApiService);
     vi.spyOn(ticketApiService, 'update').mockReturnValue(of(mockTicket));
-
+    component.ticketForm.patchValue({ comment: 'Test comment' });
     component.onSubmit();
 
     expect(ticketApiService.update).toHaveBeenCalledWith(mockTicket.id, {
-      status: mockTicket.status
+      status: mockTicket.status,
+      comment: 'Test comment'
     });
   });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
@@ -50,7 +50,8 @@ export class TicketDetailPage {
         };
 
       this.ticketApiService.update(currentTicket.id, ticketUpdate).subscribe({
-      next: () => {
+      next: (updatedTicket) => {
+        this.ticket.set(updatedTicket);
         alert('Canvi guardat!');
       }
     });

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.ts
@@ -36,7 +36,8 @@ export class TicketDetailPage {
   ];
 
   ticketForm = this.fb.group({
-      status: ['' as ITicket['status']]
+      status: ['' as ITicket['status']],
+      comment: ''
     })
 
   onSubmit() : void {
@@ -44,7 +45,8 @@ export class TicketDetailPage {
 
     if (this.ticketForm.valid && currentTicket?.id) {
       const ticketUpdate = {
-        status: this.ticketForm.value.status ?? undefined
+        status: this.ticketForm.value.status ?? undefined,
+        comment: this.ticketForm.value.comment || null
         };
 
       this.ticketApiService.update(currentTicket.id, ticketUpdate).subscribe({


### PR DESCRIPTION
#782 
**Description:** Add comment textarea to ticket detail form, allowing users to submit a status update and a comment in a single request.

- Add comment field to the reactive form
- Send comment as null if empty, or the text value on submit
- Add unit tests for textarea rendering and comment submission

Note: This branch was created from feat/782-ticket-detail-comment-textarea. Once that PR is merged, this one will be updated accordingly.