### PR TITLE
feat(challenges): show language and difficulty in challenge list page (#863)

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -1,25 +1,27 @@
 <div class="challenges-list__header">
-  <h1>Llistat de Reptes</h1>
+    <h1>Llistat de Reptes</h1>
 
-  <app-role-selector (roleChange)="onRoleChange($event)"></app-role-selector>
+    <app-role-selector
+        (roleChange)="onRoleChange($event)"
+    ></app-role-selector>
 </div>
 
-@if (isMentor()) {
-  <app-create-button></app-create-button>
+@if(isMentor()) {
+    <app-create-button></app-create-button>
 }
 
 @if (challenges().length > 0) {
-  <ul>
-    @for (challenge of challenges(); track $index) {
-      <li>
-        <h2>{{ challenge.title }}</h2>
-        <p>{{ challenge.description }}</p>
-        <p>Dificultat: {{ getDifficultyLabel(challenge.difficulty) }}</p>
-        <p>Llenguatge: {{ getLanguageLabel(challenge.language) }}</p>
-        <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
-      </li>
-    }
-  </ul>
+    <ul>
+        @for (challenge of challenges(); track $index) {
+        <li>
+            <h2>{{ challenge.title }}</h2>
+            <p>{{ challenge.description }}</p>
+            <p>Dificultat: {{ getDifficultyLabel(challenge.difficulty) }}</p>
+            <p>Llenguatge: {{ getLanguageLabel(challenge.language) }}</p>
+            <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
+        </li>
+        }
+    </ul>
 } @else {
-  <p>No hi ha reptes disponibles en aquest moment.</p>
+    <p>No hi ha reptes disponibles en aquest moment.</p>
 }

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -1,25 +1,25 @@
 <div class="challenges-list__header">
-    <h1>Llistat de Reptes</h1>
+  <h1>Llistat de Reptes</h1>
 
-    <app-role-selector
-        (roleChange)="onRoleChange($event)"
-    ></app-role-selector>
+  <app-role-selector (roleChange)="onRoleChange($event)"></app-role-selector>
 </div>
 
-@if(isMentor()) {
-    <app-create-button></app-create-button>
+@if (isMentor()) {
+  <app-create-button></app-create-button>
 }
 
 @if (challenges().length > 0) {
-    <ul>
-        @for (challenge of challenges(); track $index) {
-        <li>
-            <h2>{{ challenge.title }}</h2>
-            <p>{{ challenge.description }}</p>
-            <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
-        </li>
-        }
-    </ul>
+  <ul>
+    @for (challenge of challenges(); track $index) {
+      <li>
+        <h2>{{ challenge.title }}</h2>
+        <p>{{ challenge.description }}</p>
+        <p>Dificultat: {{ getDifficultyLabel(challenge.difficulty) }}</p>
+        <p>Llenguatge: {{ getLanguageLabel(challenge.language) }}</p>
+        <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
+      </li>
+    }
+  </ul>
 } @else {
-    <p>No hi ha reptes disponibles en aquest moment.</p>
+  <p>No hi ha reptes disponibles en aquest moment.</p>
 }

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -15,16 +15,12 @@ describe('ChallengesListPage', () => {
   let mockChallengeService: any;
 
   beforeEach(async () => {
-    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK))};
+    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK)) };
 
     await TestBed.configureTestingModule({
       imports: [ChallengesListPage],
-      providers: [
-        provideRouter([]),
-        { provide: ChallengeService, useValue: mockChallengeService }
-      ]
-    })
-    .compileComponents();
+      providers: [provideRouter([]), { provide: ChallengeService, useValue: mockChallengeService }],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ChallengesListPage);
     component = fixture.componentInstance;
@@ -45,6 +41,21 @@ describe('ChallengesListPage', () => {
 
     expect(listItems.length).toBe(CHALLENGES_MOCK.length);
     expect(listItems[0].textContent).toContain(CHALLENGES_MOCK[0].title);
+  });
+
+  it('should return correct difficulty and language labels', () => {
+    expect(component.getDifficultyLabel('EASY')).toBe('Fàcil');
+    expect(component.getDifficultyLabel('MEDIUM')).toBe('Mitjana');
+    expect(component.getDifficultyLabel('HARD')).toBe('Difícil');
+    expect(component.getDifficultyLabel()).toBe('');
+
+    expect(component.getLanguageLabel('JAVA')).toBe('Java');
+    expect(component.getLanguageLabel('PYTHON')).toBe('Python');
+    expect(component.getLanguageLabel('JAVASCRIPT')).toBe('JavaScript');
+    expect(component.getLanguageLabel('TYPESCRIPT')).toBe('TypeScript');
+    expect(component.getLanguageLabel('PHP')).toBe('PHP');
+    expect(component.getLanguageLabel('SQL')).toBe('SQL');
+    expect(component.getLanguageLabel()).toBe('');
   });
 
   it('should render role selector component', () => {

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -15,12 +15,16 @@ describe('ChallengesListPage', () => {
   let mockChallengeService: any;
 
   beforeEach(async () => {
-    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK)) };
+    mockChallengeService = { loadAll: vi.fn().mockReturnValue(of(CHALLENGES_MOCK))};
 
     await TestBed.configureTestingModule({
       imports: [ChallengesListPage],
-      providers: [provideRouter([]), { provide: ChallengeService, useValue: mockChallengeService }],
-    }).compileComponents();
+      providers: [
+        provideRouter([]), 
+        { provide: ChallengeService, useValue: mockChallengeService }
+      ],
+    })
+    .compileComponents();
 
     fixture = TestBed.createComponent(ChallengesListPage);
     component = fixture.componentInstance;

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,11 +1,11 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { RouterLink } from "@angular/router";
-
+import { RouterLink } from '@angular/router';
+import { ChallengeLanguage } from '../../models/challenge-language.type';
+import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
 import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
-import { DeleteButtonComponent } from "../../components/buttons/delete-button/delete-button";
 
 @Component({
   selector: 'app-challenges-list-page',
@@ -13,7 +13,6 @@ import { DeleteButtonComponent } from "../../components/buttons/delete-button/de
     RouterLink, 
     RoleSelectorComponent, 
     CreateButtonComponent, 
-    DeleteButtonComponent
   ],
   standalone: true,
   templateUrl: './challenges-list-page.html',

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,10 +1,11 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
-import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
+import { RoleSelectorComponent } from '../../components/role-selector/role-selector';
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
-import { RouterLink } from "@angular/router";
-
+import { RouterLink } from '@angular/router';
+import { ChallengeLanguage } from '../../models/challenge-language.type';
+import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 @Component({
   selector: 'app-challenges-list-page',
   imports: [CreateButtonComponent, RoleSelectorComponent, RouterLink],
@@ -13,21 +14,43 @@ import { RouterLink } from "@angular/router";
   styleUrl: './challenges-list-page.css',
 })
 export class ChallengesListPage implements OnInit {
-
   private readonly challengesService = inject(ChallengeService);
 
   challenges = signal<IChallenge[]>([]);
   isMentor = signal(false);
 
+  languageLabels: Record<ChallengeLanguage, string> = {
+    JAVA: 'Java',
+    PHP: 'PHP',
+    JAVASCRIPT: 'JavaScript',
+    TYPESCRIPT: 'TypeScript',
+    PYTHON: 'Python',
+    SQL: 'SQL',
+  };
+
+  difficultyLabels: Record<ChallengeDifficulty, string> = {
+    EASY: 'Fàcil',
+    MEDIUM: 'Mitjana',
+    HARD: 'Difícil',
+  };
+
   ngOnInit(): void {
     this.loadChallenges();
+  }
+
+  getLanguageLabel(lang?: ChallengeLanguage): string {
+    return lang ? this.languageLabels[lang] : '';
+  }
+
+  getDifficultyLabel(diff?: ChallengeDifficulty): string {
+    return diff ? this.difficultyLabels[diff] : '';
   }
 
   loadChallenges(): void {
     this.challengesService.loadAll().subscribe({
       next: (result) => {
         this.challenges.set(result);
-      }
+      },
     });
   }
 

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -1,9 +1,9 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
-import { RoleSelectorComponent } from '../../components/role-selector/role-selector';
+import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
-import { RouterLink } from '@angular/router';
+import { RouterLink } from "@angular/router";
 import { ChallengeLanguage } from '../../models/challenge-language.type';
 import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
 @Component({
@@ -14,6 +14,7 @@ import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
   styleUrl: './challenges-list-page.css',
 })
 export class ChallengesListPage implements OnInit {
+
   private readonly challengesService = inject(ChallengeService);
 
   challenges = signal<IChallenge[]>([]);
@@ -50,7 +51,7 @@ export class ChallengesListPage implements OnInit {
     this.challengesService.loadAll().subscribe({
       next: (result) => {
         this.challenges.set(result);
-      },
+      }
     });
   }
 

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -6,6 +6,7 @@ import { IChallenge } from '../../models/ichallenge.interface';
 import { ChallengeService } from '../../services/challenge.service';
 import { RoleSelectorComponent } from "../../components/role-selector/role-selector";
 import { CreateButtonComponent } from '../../components/buttons/create-button/create-button';
+import { DeleteButtonComponent } from "../../components/buttons/delete-button/delete-button";
 
 @Component({
   selector: 'app-challenges-list-page',
@@ -13,6 +14,7 @@ import { CreateButtonComponent } from '../../components/buttons/create-button/cr
     RouterLink, 
     RoleSelectorComponent, 
     CreateButtonComponent, 
+    DeleteButtonComponent
   ],
   standalone: true,
   templateUrl: './challenges-list-page.html',


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/863)

## What's included
- Displayed `ChallengeLanguage` in the challenge list page
- Displayed `ChallengeDifficulty` in the challenge list page
- Added label mapping for `language` values (e.g. JAVASCRIPT → JavaScript)
- Added label mapping for `difficulty` values (EASY → Fàcil, etc.)
- Updated unit tests to verify UI rendering of new fields