### PR TITLE
feat(challenges) add publish solution flow with mock implementation and tests (#837)

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.spec.ts
@@ -168,4 +168,18 @@ describe('ChallengeApiService', () => {
       req.flush(null);
     });
   });
+
+  describe('publishSolution', () => {
+    it('should return void (mocked implementation)', () => {
+      const payload: IChallengeSubmission = {
+        challengeId: 'abc-123',
+        userId: 'abc-345',
+        code: 'code'
+      };
+
+      service.publishSolution(payload).subscribe(result => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
 });

--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
@@ -62,4 +62,8 @@ export class ChallengeApiService {
   saveSolution(payload: IChallengeSubmission): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/submissions`, payload);
   }
+
+  publishSolution(payload: IChallengeSubmission): Observable<void> {
+    return of(void 0);
+  }
 }

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.css
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.css
@@ -1,0 +1,11 @@
+.challenge__form {
+    display: flex;
+    flex-direction: column;
+    max-width: 50rem;
+    gap: 1rem;
+}
+
+.challenge__actions {
+    display: flex;
+    gap: 1rem;
+}

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -2,13 +2,16 @@
 @if (challenge()) {
   <h1>{{ challenge()?.title }}</h1>
   <p>{{ challenge()?.description}}</p>
-  <form [formGroup]="codeSolutionForm" (ngSubmit)="saveSolution()">
+  <form [formGroup]="codeSolutionForm" (ngSubmit)="saveSolution()" class="challenge__form">
     <textarea
         id="challengeAnswer"
         formControlName="code"
         rows="10"
         placeholder="Escriu aquí la resposta del repte...">
       </textarea>
-    <button type="submit">Guardar</button>
+    <div class="challenge__actions">
+      <button type="submit">Guardar</button>
+      <button type="button" (click)="publishSolution()">Publicar</button>
+    </div>
   </form>
 }

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -23,7 +23,10 @@ describe('ChallengeDetailPage', () => {
   beforeEach(async () => {
     mockChallengeService = { getById: vi.fn().mockReturnValue(of(mockChallenge)) };
     mockActivatedRoute = { snapshot: { paramMap: { get: vi.fn().mockReturnValue('test-123') } } };
-    mockChallengeApiService = {postSolution: vi.fn().mockReturnValue(of({}))};
+    mockChallengeApiService = {
+      saveSolution: vi.fn().mockReturnValue(of({})),
+      publishSolution: vi.fn().mockReturnValue(of({}))
+    };
     mockAuthService = {user: vi.fn().mockReturnValue({ id: 'user-456' })};
 
     await TestBed.configureTestingModule({
@@ -63,6 +66,18 @@ describe('ChallengeDetailPage', () => {
     component.saveSolution();
 
     expect(mockChallengeApiService.saveSolution).toHaveBeenCalledWith({
+      challengeId: 'test-123',
+      userId: 'user-456',
+      code: 'my-code'
+    });
+  });
+
+  it('should call publishSolution with form data and challengeId', () => {
+    fixture.detectChanges();
+    component.codeSolutionForm.patchValue({ code: 'my-code' });
+    component.publishSolution();
+
+    expect(mockChallengeApiService.publishSolution).toHaveBeenCalledWith({
       challengeId: 'test-123',
       userId: 'user-456',
       code: 'my-code'

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -57,4 +57,25 @@ export class ChallengeDetailPage {
       });
       }
     }
+
+  publishSolution(): void {
+    const currentChallenge = this.challenge();
+    const currentUser = this.authService.user() as AuthUserWithId;
+
+    if(this.codeSolutionForm.valid && currentChallenge?.id) {
+      const challengeSolution : IChallengeSubmission = {
+        challengeId: currentChallenge.id,
+        userId: currentUser?.id || '550e8400-e29b-41d4-a716-446655440000',
+        code: this.codeSolutionForm.value.code ?? ''
+      };
+      this.challengeApiService.publishSolution(challengeSolution).subscribe({
+        next: () => {
+          alert('Solució publicada!');
+        },
+        error: (err) => {
+          console.error('Error en publicar la solució:', err);
+        }
+      });
+    }
+  }
 }


### PR DESCRIPTION
### [Issue Here](https://github.com/IT-Academy-BCN/ita-challenges/issues/837)

## Summary

Implemented the initial publish solution feature for challenges, adding a new action that allows users to submit their final solution separately from saving a draft. Since the backend endpoint is not yet available, the current implementation uses a mocked Observable response, preparing the architecture for future integration.

This change extends the challenge submission flow by introducing a clear separation between saving and publishing a solution.

## What's included

- Added `publishSolution` method in `ChallengeApiService` returning a mocked `Observable<void>`
- Added `publishSolution` handler in `ChallengeDetailPage` with form validation and payload creation
- Integrated user action via new “Publicar” button in the challenge detail UI
- Added unit test to ensure consistency with new publish flow structure in:  
   - `ChallengeDetailPage`
   - `ChallengeApiService`

> This feature prepares the codebase for future backend integration of the publish endpoint while maintaining current stability and test coverage.

> Minimal styles were introduced to ensure proper layout distribution and correct UI functionality.