### PR TITLE
Feature/858 view ticket comment

### DIFF
--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.css
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.css
@@ -1,0 +1,6 @@
+.ticket-comment-section {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+}

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -3,31 +3,32 @@
 </div>
 
 @if (ticket(); as t) {
-  <h1>{{ t.title }}</h1>
-  <p>Usuari ID: {{ t.userId }}</p>
-  <p>{{ t.description }}</p>
+<h1>{{ t.title }}</h1>
+<p>Usuari ID: {{ t.userId }}</p>
+<p>{{ t.description }}</p>
 
-  @if (isMentor()) {
-    <form [formGroup]="ticketForm" (ngSubmit)="onSubmit()">
-      <select id="status" formControlName="status">
-        <option value="" disabled>Selecciona l'estat</option>
-        @for (status of statusOptions; track $index) {
-          <option [value]="status.value">{{ status.label }}</option>
-        }
-      </select>
+@if (isMentor()) {
+<form [formGroup]="ticketForm" (ngSubmit)="onSubmit()">
+  <select id="status" formControlName="status">
+    <option value="" disabled>Selecciona l'estat</option>
+    @for (status of statusOptions; track $index) {
+    <option [value]="status.value">{{ status.label }}</option>
+    }
+  </select>
 
-      <div>
-        <label for="comment">Afegir comentari:</label><br>
-        <textarea id="comment" rows="10" formControlName="comment"></textarea>
-      </div>
+  <div>
+    <label for="comment">Afegir comentari:</label><br>
+    <textarea id="comment" rows="10" formControlName="comment"></textarea>
+  </div>
 
-      <button type="submit">Guardar</button>
-    </form>
+  <button type="submit">Guardar</button>
+</form>
+}
 
 @if (t.comment) {
-  <div class="ticket-comment-section">
-    <h4>Ultim comentari:</h4>
-    <p>{{ t.comment }}</p>
-  </div>
+<div class="ticket-comment-section">
+  <h4>Ultim comentari:</h4>
+  <p>{{ t.comment }}</p>
+</div>
 }
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -15,9 +15,9 @@
     </div>
 
 @if (ticket.comment) {
-<div class="ticket-comment-section mt-4 p-3 border rounded">
-  <h4>Ultim comentari:</h4>
-  <p>{{ ticket.comment }}</p>
-</div>
+  <div class="ticket-comment-section mt-4 p-3 border rounded">
+    <h4>Ultim comentari:</h4>
+    <p>{{ ticket.comment }}</p>
+  </div>
 }
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -15,7 +15,7 @@
     </div>
 
 @if (ticket.comment) {
-  <div class="ticket-comment-section mt-4 p-3 border rounded">
+  <div class="ticket-comment-section">
     <h4>Ultim comentari:</h4>
     <p>{{ ticket.comment }}</p>
   </div>

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -16,7 +16,7 @@
 
 @if (ticket.comment) {
 <div class="ticket-comment-section mt-4 p-3 border rounded">
-  <h4>Ultimo comentario:</h4>
+  <h4>Ultim comentari:</h4>
   <p>{{ ticket.comment }}</p>
 </div>
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.html
@@ -13,4 +13,11 @@
       <label for="comment">Comentari del Mentor:</label><br>
       <textarea id="comment" rows="10"></textarea>
     </div>
+
+@if (ticket.comment) {
+<div class="ticket-comment-section mt-4 p-3 border rounded">
+  <h4>Ultimo comentario:</h4>
+  <p>{{ ticket.comment }}</p>
+</div>
+}
 }

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TicketDetailPage } from './ticket-detail-page';
 import { TICKETS_MOCK } from '../../models/tickets.mock';
+import { By } from '@angular/platform-browser';
 
 describe('TicketDetailPage', () => {
   let component: TicketDetailPage;
@@ -43,8 +44,34 @@ describe('TicketDetailPage', () => {
   it('should render the comment textarea', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const textareaElement = compiled.querySelector('textarea');
+
     expect(textareaElement).toBeTruthy();
     expect(textareaElement?.getAttribute('id')).toBe('comment');
     expect(textareaElement?.getAttribute('rows')).toBe('10');
   });
-});
+
+ it('should NOT render the comment section if ticket.comment is null or undefined', () => {
+     const freshFixture = TestBed.createComponent(TicketDetailPage);
+     const freshComponent = freshFixture.componentInstance;
+     freshComponent.ticket = { ...TICKETS_MOCK[0], comment: null as any };
+     freshFixture.detectChanges();
+
+     const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
+
+     expect(commentSection).toBeNull();
+   });
+
+   it('should render the comment section if ticket.comment has text', () => {
+     const freshFixture = TestBed.createComponent(TicketDetailPage);
+     const freshComponent = freshFixture.componentInstance;
+     const testComment = 'This is a test comment for testing purposes.';
+     freshComponent.ticket = { ...TICKETS_MOCK[0], comment: testComment };
+     freshFixture.detectChanges();
+
+     const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
+
+     expect(commentSection).toBeTruthy();
+     expect(commentSection.nativeElement.textContent).toContain(testComment);
+   });
+ });
+

--- a/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-detail-page/ticket-detail-page.spec.ts
@@ -34,6 +34,8 @@ describe('TicketDetailPage', () => {
 
     fixture = TestBed.createComponent(TicketDetailPage);
     component = fixture.componentInstance;
+    component.isMentor.set(true);
+
     fixture.detectChanges();
     await fixture.whenStable();
   });
@@ -68,6 +70,7 @@ describe('TicketDetailPage', () => {
   it('should call update on submit', () => {
     const ticketApiService = TestBed.inject(TicketApiService);
     vi.spyOn(ticketApiService, 'update').mockReturnValue(of(mockTicket));
+
     component.ticketForm.patchValue({ comment: 'Test comment' });
     component.onSubmit();
 
@@ -75,7 +78,7 @@ describe('TicketDetailPage', () => {
       status: mockTicket.status,
       comment: 'Test comment'
     });
-  })
+  });
 
   it('should render the comment textarea', () => {
     const compiled = fixture.nativeElement as HTMLElement;
@@ -86,28 +89,33 @@ describe('TicketDetailPage', () => {
     expect(textareaElement?.getAttribute('rows')).toBe('10');
   });
 
- it('should NOT render the comment section if ticket.comment is null or undefined', () => {
-     const ticketService = TestBed.inject(TicketService);
-     vi.spyOn(ticketService, 'getById').mockReturnValue(of({ ...TICKETS_MOCK[0], comment: null as any }));
+  it('should NOT render the comment section if ticket.comment is null or undefined', async () => {
+    const ticketService = TestBed.inject(TicketService);
+    vi.spyOn(ticketService, 'getById').mockReturnValue(of({ ...TICKETS_MOCK[0], comment: null as any }));
 
-     const freshFixture = TestBed.createComponent(TicketDetailPage);
-     freshFixture.detectChanges();
+    const freshFixture = TestBed.createComponent(TicketDetailPage);
 
-     const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
-     expect(commentSection).toBeNull();
-   });
+    freshFixture.detectChanges();
+    await freshFixture.whenStable();
+    freshFixture.detectChanges();
 
-   it('should render the comment section if ticket.comment has text', () => {
-     const testComment = 'This is a test comment for testing purposes.';
-     const ticketService = TestBed.inject(TicketService);
-     vi.spyOn(ticketService, 'getById').mockReturnValue(of({ ...TICKETS_MOCK[0], comment: testComment }));
+    const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
+    expect(commentSection).toBeNull();
+  });
 
-     const freshFixture = TestBed.createComponent(TicketDetailPage);
-     freshFixture.detectChanges();
+  it('should render the comment section if ticket.comment has text', async () => {
+    const testComment = 'This is a test comment for testing purposes.';
+    const ticketService = TestBed.inject(TicketService);
+    vi.spyOn(ticketService, 'getById').mockReturnValue(of({ ...TICKETS_MOCK[0], comment: testComment }));
 
-     const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
-     expect(commentSection).toBeTruthy();
-     expect(commentSection.nativeElement.textContent).toContain(testComment);
-   });
- });
+    const freshFixture = TestBed.createComponent(TicketDetailPage);
 
+    freshFixture.detectChanges();
+    await freshFixture.whenStable();
+    freshFixture.detectChanges();
+
+    const commentSection = freshFixture.debugElement.query(By.css('.ticket-comment-section'));
+    expect(commentSection).toBeTruthy();
+    expect(commentSection.nativeElement.textContent).toContain(testComment);
+  });
+});


### PR DESCRIPTION
## Description
This PR resolves the task to display the latest ticket comment on the Ticket Detail Page. It implements conditional rendering to ensure the comment section is only visible when data exists, avoiding empty blocks in the UI.

Additionally, some static strings in the view were translated to Catalan to improve localization.

## Related Ticket
- Task: #858 (or paste the Jira/Trello link here)

## Changes Made
- Added an `@if (ticket.comment)` block in `ticket-detail-page.html` to conditionally render the comment section.
- Ensured the comment field is visible for both student and mentor roles (no role guards applied).
- Updated `tickets.mock.ts` to include comment data for local testing.
- **chore(i18n):** Translated UI labels and default texts in the ticketing view to Catalan.

## How to Test
1. Checkout to this branch (`feature/858-view-ticket-comment`).
2. Run `npm start` (or `ng serve`).
3. Navigate to `http://localhost:4200/tickets/1` (or click on the first ticket in the list).
4. Verify that the "Último comentario" box appears correctly with the mock text.
5. In `tickets.mock.ts`, temporarily remove or set the comment to `null`, reload, and verify that the comment box completely disappears from the UI.

## Screenshots
<img width="1920" height="1080" alt="8f7efca5-c0d3-40db-9a70-542524d6764b" src="https://github.com/user-attachments/assets/0e0f92bd-24db-4db9-98fb-e5bffdb6a340" />
