### PR TITLE
731 auth   display the role in the header on the right

### DIFF
--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -6,6 +6,7 @@ import { vi } from 'vitest';
 
 import { AuthService } from './auth-service';
 import { AuthUser } from '../models/auth-user.model';
+import { Role } from '../../../core/models/role.enum';
 
 const MOCK_USER: AuthUser = {
   username: 'mockUser',
@@ -67,17 +68,6 @@ describe('AuthService', () => {
     vi.unstubAllGlobals();
   });
 
-  it('should fetch user from API', async () => {
-    const promise = firstValueFrom(service.fetchUser());
-
-    const req = httpMock.expectOne('/api/account/auth/me');
-    expect(req.request.method).toBe('GET');
-    req.flush(MOCK_USER);
-
-    const result = await promise;
-    expect(result).toEqual(MOCK_USER);
-  });
-
   it('should clear current user on logout', async () => {
     service.setUser(MOCK_USER);
 
@@ -90,5 +80,20 @@ describe('AuthService', () => {
     await promise;
 
     expect(service.user()).toBeNull();
+  });
+
+  it('should fetch user and role from API', async () => {
+    const promise = firstValueFrom(service.fetchUser());
+    httpMock.expectOne('/api/account/auth/me').flush(MOCK_USER);
+    httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`).flush({ role: Role.GUEST });
+    expect(await promise).toEqual({ ...MOCK_USER, role: Role.GUEST });
+  });
+
+  it('should load user without role if role endpoint fails', async () => {
+    const promise = firstValueFrom(service.fetchUser());
+    httpMock.expectOne('/api/account/auth/me').flush(MOCK_USER);
+    httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`)
+      .flush('', { status: 404, statusText: 'Not Found' });
+    expect(await promise).toEqual({ ...MOCK_USER, role: undefined });
   });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -88,12 +88,4 @@ describe('AuthService', () => {
     httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`).flush({ role: Role.GUEST });
     expect(await promise).toEqual({ ...MOCK_USER, role: Role.GUEST });
   });
-
-  it('should load user without role if role endpoint fails', async () => {
-    const promise = firstValueFrom(service.fetchUser());
-    httpMock.expectOne('/api/account/auth/me').flush(MOCK_USER);
-    httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`)
-      .flush('', { status: 404, statusText: 'Not Found' });
-    expect(await promise).toEqual({ ...MOCK_USER, role: undefined });
-  });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
+import { map, Observable, switchMap, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
 import { Role } from '../../../core/models/role.enum';
@@ -25,8 +25,6 @@ export class AuthService {
       switchMap(user =>
         this.getUserRole(user.username).pipe(
           map(role => ({ ...user, role })),
-
-          catchError(() => of({ ...user, role: undefined }))
         )
       )
     );

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,17 +1,18 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { map, Observable, tap } from 'rxjs';
+import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
+import { Role } from '../../../core/models/role.enum';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   private readonly http = inject(HttpClient);
-
   private readonly githubLoginUrl = '/api/account/oauth2/authorization/github';
   private readonly currentUserUrl = '/api/account/auth/me';
   private readonly logoutUrl = '/api/account/auth/logout';
+  private readonly userRoleUrl = (username: string) => `/api/account/users/${username}/role`;
 
   user = signal<AuthUser | null>(null);
 
@@ -20,7 +21,20 @@ export class AuthService {
   }
 
   fetchUser(): Observable<AuthUser> {
-    return this.http.get<AuthUser>(this.currentUserUrl);
+    return this.http.get<AuthUser>(this.currentUserUrl).pipe(
+      switchMap(user =>
+        this.getUserRole(user.username).pipe(
+          map(role => ({ ...user, role })),
+
+          catchError(() => of({ ...user, role: undefined }))
+        )
+      )
+    );
+  }
+
+  private getUserRole(username: string): Observable<Role> {
+    return this.http.get<{ role: Role }>(this.userRoleUrl(username))
+      .pipe(map(response => response.role));
   }
 
   setUser(user: AuthUser): void {

--- a/frontend/src/app/features/auth/models/auth-user.model.ts
+++ b/frontend/src/app/features/auth/models/auth-user.model.ts
@@ -1,5 +1,8 @@
+import { Role } from "../../../core/models/role.enum";
+
 export interface AuthUser {
   username: string;
   avatarUrl: string;
   token?: string;
+  role?: Role;
 }

--- a/frontend/src/app/layout/components/header/header.html
+++ b/frontend/src/app/layout/components/header/header.html
@@ -2,7 +2,17 @@
   <h1>IT ACADEMY</h1>
 
   @if (user()) {
-    <h4 >
+    @if (user()?.role) {
+      <h4 class="user__profile">
+        {{ user()?.role }}
+      </h4>
+    } @else {
+       <h4 class="user__profile">
+        CONVIDAT
+      </h4>
+    }
+
+    <h4 class="user__profile">
       {{ user()?.username }}
     </h4>
 

--- a/frontend/src/app/layout/components/header/header.html
+++ b/frontend/src/app/layout/components/header/header.html
@@ -2,16 +2,9 @@
   <h1>IT ACADEMY</h1>
 
   @if (user()) {
-    @if (user()?.role) {
-      <h4 class="user__profile">
-        {{ user()?.role }}
-      </h4>
-    } @else {
-       <h4 class="user__profile">
-        CONVIDAT
-      </h4>
-    }
-
+    <h4 class="user__profile">
+      {{ user()?.role ?? 'CONVIDAT' }}
+    </h4>
     <h4 class="user__profile">
       {{ user()?.username }}
     </h4>

--- a/frontend/src/app/layout/components/header/header.spec.ts
+++ b/frontend/src/app/layout/components/header/header.spec.ts
@@ -5,11 +5,13 @@ import { signal } from '@angular/core';
 import { AuthUser } from '../../../features/auth/models/auth-user.model';
 import { of } from 'rxjs';
 import { AuthService } from '../../../features/auth/data-access/auth-service';
+import { Role } from '../../../core/models/role.enum';
 
 const MOCK_USER: AuthUser = {
   username: 'mockUser',
   avatarUrl: 'https://github.com/MockUser.png',
   token: 'token-808',
+  role: Role.GUEST,
 };
 
 describe('Header', () => {
@@ -19,14 +21,18 @@ describe('Header', () => {
   let authServiceMock: {
     user: ReturnType<typeof signal<AuthUser | null>>;
     logout: ReturnType<typeof vi.fn>;
+    fetchUser: ReturnType<typeof vi.fn>;
+    getUser: ReturnType<typeof vi.fn>;
+    setUser: ReturnType<typeof vi.fn>;
   };
-
   beforeEach(async () => {
     authServiceMock = {
       user: signal(null),
       logout: vi.fn().mockReturnValue(of(void 0)),
+      fetchUser: vi.fn().mockReturnValue(of(null)),
+      getUser: vi.fn().mockReturnValue(null),
+      setUser: vi.fn(),
     };
-
     await TestBed.configureTestingModule({
       imports: [Header],
       providers: [
@@ -60,8 +66,11 @@ describe('Header', () => {
     authServiceMock.user.set(MOCK_USER);
     fixture.detectChanges();
 
-    const h4 = fixture.nativeElement.querySelector('h4');
-    expect(h4.textContent).toContain(MOCK_USER.username);
+    const h4s = fixture.nativeElement.querySelectorAll('h4');
+    const usernameEl = Array.from(h4s).find((el: any) =>
+      el.textContent.includes(MOCK_USER.username)
+    );
+    expect(usernameEl).toBeTruthy();
   });
 
   it('should not show username when user is not logged in', () => {
@@ -87,5 +96,17 @@ describe('Header', () => {
 
     const avatar = fixture.nativeElement.querySelector('.avatar__image');
     expect(avatar).toBeFalsy();
+  });
+
+  it('should show user role when user has a role', () => {
+    authServiceMock.user.set({ ...MOCK_USER, role: Role.GUEST });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('h4').textContent).toContain(Role.GUEST);
+  });
+
+  it('should show CONVIDAT when user has no role', () => {
+    authServiceMock.user.set({ ...MOCK_USER, role: undefined });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('h4').textContent).toContain('CONVIDAT');
   });
 });

--- a/frontend/src/app/layout/components/header/header.ts
+++ b/frontend/src/app/layout/components/header/header.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, OnInit } from '@angular/core';
 import { LogoutButton } from '../../../shared/components/logout-button/logout-button';
 import { AuthService } from '../../../features/auth/data-access/auth-service';
 
@@ -8,8 +8,16 @@ import { AuthService } from '../../../features/auth/data-access/auth-service';
   templateUrl: './header.html',
   styleUrl: './header.css',
 })
-export class Header {
+export class Header implements OnInit{
   private readonly authService = inject(AuthService);
 
-  public user = this.authService.user;
+  public user = computed(() => this.authService.user());
+
+  ngOnInit(): void {
+    if (this.authService.getUser()) return;
+
+    this.authService.fetchUser().subscribe({
+      next: (user) => this.authService.setUser(user),
+    });
+  }
 }


### PR DESCRIPTION
### Show the logged-in user's role in the header

Description:
When a user is logged in, their role is now displayed in the header of the application alongside their username and avatar. If the role is not available, a default 'CONVIDAT' label is shown as fallback. This way, users can easily see at a glance which account and role they are currently using, improving the overall experience and making the interface feel more informative.

To ensure the user data is available on any route and not only when navigating through the profile page, the header now fetches the user on initialization. Additionally, the role fetch in AuthService has been made fault-tolerant: if the role endpoint is unavailable or returns an error, the user is still loaded correctly without a role, preventing unwanted redirects to the login page.