### PR TITLE
feat(auth-service): handle role endpoint failure #731

### DIFF
--- a/frontend/src/app/features/auth/data-access/auth-service.spec.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.spec.ts
@@ -88,4 +88,12 @@ describe('AuthService', () => {
     httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`).flush({ role: Role.GUEST });
     expect(await promise).toEqual({ ...MOCK_USER, role: Role.GUEST });
   });
+
+  it('should load user without role if role endpoint fails', async () => {
+    const promise = firstValueFrom(service.fetchUser());
+    httpMock.expectOne('/api/account/auth/me').flush(MOCK_USER);
+    httpMock.expectOne(`/api/account/users/${MOCK_USER.username}/role`)
+      .flush('', { status: 404, statusText: 'Not Found' });
+    expect(await promise).toEqual({ ...MOCK_USER, role: undefined });
+  });
 });

--- a/frontend/src/app/features/auth/data-access/auth-service.ts
+++ b/frontend/src/app/features/auth/data-access/auth-service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { map, Observable, switchMap, tap } from 'rxjs';
+import { catchError, map, Observable, of, switchMap, tap } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { AuthUser } from '../models/auth-user.model';
 import { Role } from '../../../core/models/role.enum';
@@ -25,6 +25,7 @@ export class AuthService {
       switchMap(user =>
         this.getUserRole(user.username).pipe(
           map(role => ({ ...user, role })),
+          catchError(() => of({ ...user, role: undefined }))
         )
       )
     );


### PR DESCRIPTION
**Description:**

When fetching the logged-in user, AuthService also requests their role from a separate endpoint. If that endpoint is unavailable or returns an error, the observable would fail, causing the auth guard to redirect the user back to the login page in an uncontrolled way.

This PR adds a catchError to the role fetch so that, if it fails, the user is still loaded correctly without a role instead of breaking the authentication flow. The fallback sets the role to undefined, which the header already handles by displaying the default 'CONVIDAT' label.