### PR TITLE
feat: Configure logout endpoint to invalidate session and delete cookie

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -29,6 +29,13 @@ public class SecurityConfig {
                                 .baseUri("/api/account/login/oauth2/code/**")
                         )
                         .defaultSuccessUrl("/profile", true)
+                )
+                .logout(logout -> logout
+                .logoutUrl("/api/account/auth/logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID", "remember-me")
+                .logoutSuccessHandler((request, response, authentication) ->
+                        response.setStatus(200))
                 );
         return http.build();
     }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -15,6 +15,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,5 +63,12 @@ class SecurityConfigTest {
    .andExpect(status().is3xxRedirection())
    .andExpect(redirectedUrlPattern("**/auth"));
  }
+
+ @Test
+ @DisplayName("Should permit POST requests to logout endpoint")
+ void shouldPermitLogoutEndpoint() throws Exception {
+  mockMvc.perform(post("/api/account/auth/logout"))
+   .andExpect(status().isOk());
+    }
 
 }


### PR DESCRIPTION
Currently, when a user logs out and refreshes the page,
the session is automatically restored due to the JSESSIONID cookie.

Changes:

Added logout configuration in SecurityConfig with endpoint POST /api/account/auth/logout
Invalidate HTTP session on logout
Delete JSESSIONID cookie on logout
Added logout endpoint to permitted URLs
Updated SecurityConfigTest with missing mocks
Expected behavior:
After logout, refreshing the page keeps the user logged out.

Closes #766 