### PR TITLE
731 auth   display the role in the header on the right

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,5 +1,6 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
+import com.ita.challenges.account.domain.model.Role;
 import com.ita.challenges.account.domain.port.out.UserRepository;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserRoleResponse;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,6 @@ public class UserController {
     public ResponseEntity<UserRoleResponse> getUserRole(@PathVariable String username) {
         return userRepository.findByUsername(username)
                 .map(user -> ResponseEntity.ok(new UserRoleResponse(user.userRole())))
-                .orElse(ResponseEntity.notFound().build());
+                .orElse(ResponseEntity.ok(new UserRoleResponse(Role.GUEST)));
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/account/auth/**").permitAll()
                         .requestMatchers("/api/account/oauth2/**").permitAll()
                         .requestMatchers("/api/account/login/oauth2/**").permitAll()
+                        .requestMatchers("/api/account/users/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -42,10 +42,11 @@ class UserControllerTest {
 
     @Test
     @WithMockUser
-    void shouldReturn404WhenUserNotFound() throws Exception {
+    void shouldReturnGuestRoleWhenUserNotFound() throws Exception {
         when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/account/users/unknown/role"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("GUEST"));
     }
 }


### PR DESCRIPTION
## Description
When a user logs in with GitHub, they may not yet exist in the database (no role assigned). The previous implementation returned a 404 in that case, which caused the frontend auth flow to fail and redirect the user back to the login page.

## Changes
- `SecurityConfig`: allow unauthenticated access to `/api/account/users/**`
- `UserController`: return `GUEST` role instead of 404 when user is not found in the repository
- update UserControllerTest to expect GUEST role when user not found

## Related issue
[#731](https://github.com/IT-Academy-BCN/ita-challenges/issues/731)