### PR TITLE
fix: challenge list page now showing the difficulty and language fields again

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.html
@@ -16,7 +16,9 @@
         <li>
             <h2>{{ challenge.title }}</h2>
             <p>{{ challenge.description }}</p>
-
+            <p>Dificultat: {{ getDifficultyLabel(challenge.difficulty) }}</p>
+            <p>Llenguatge: {{ getLanguageLabel(challenge.language) }}</p>
+            
             <div class="challenges-list__actions">
                 <button [routerLink]="['/challenges', challenge.id]">Accedir al repte</button>
                 @if(isMentor()) {


### PR DESCRIPTION
Added:

- Difficulty and language fields to the challenge-list-page.html again. They were missing due to a merge conflict.