### PR TITLE
Persist challenge deletion in database

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -73,7 +73,7 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
         try {
             persistToFile();
         } catch (IOException e) {
-            throw new RuntimeException("Failed to persist after delete");
+            throw new RuntimeException("Failed to persist after delete", e);
 
         }
     }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepository.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Primary
@@ -63,7 +64,18 @@ public class JsonFileChallengeRepository implements ChallengeRepository {
 
     @Override
     public void delete(ChallengeId id) {
-        throw new UnsupportedOperationException("Not implemented yet");
+
+        if(!storage.containsKey(id)) {
+            throw new NoSuchElementException("Challenge with this id doesn't exist");
+        }
+
+        storage.remove(id);
+        try {
+            persistToFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to persist after delete");
+
+        }
     }
 
     @Override

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -50,4 +50,21 @@ class JsonFileChallengeRepositoryTest {
         assertThat(repository.findAll().get(0).getTitle().toString())
                 .isEqualTo("Clean Code");
     }
+
+    @Test
+    void delete_should_remove_challenge_from_storage() {
+
+        Challenge challenge = Challenge.create(
+                "Clean Code",
+                "Write readable code",
+                ChallengeLanguage.JAVA,
+                ChallengeDifficulty.EASY,
+                "Challenge solution"
+        );
+
+        repository.save(challenge);
+        repository.delete(challenge.getId());
+
+        assertThat(repository.findAll()).isEmpty();
+    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/JsonFileChallengeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.ou
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import org.junit.jupiter.api.AfterEach;
@@ -10,8 +11,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsonFileChallengeRepositoryTest {
 
@@ -67,4 +70,12 @@ class JsonFileChallengeRepositoryTest {
 
         assertThat(repository.findAll()).isEmpty();
     }
+
+    @Test
+    void delete_should_throw_when_challenge_does_not_exist() {
+        ChallengeId fakeId = ChallengeId.generate();
+
+        assertThrows(NoSuchElementException.class, () -> repository.delete(fakeId));
+    }
+
 }


### PR DESCRIPTION
This change adds the delete method in JsonFileChallengeRepository class, and the happy past test to its test file. Thanks to it now the deletion of the challenges should persist since it now deletes from the generated file and not from RAM memory- 