### PR TITLE
"test: add integration test for secure logout validation"

### DIFF
--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/LogoutIntegrationTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/LogoutIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.ita.challenges.account.infrastructure.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LogoutIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Should return 200 OK and invalidate JSESSIONID cookie on logout")
+    @WithMockUser(username = "user")
+    void testSuccessfulLogoutInvalidatesSession() throws Exception {
+
+        mockMvc.perform(post("/api/account/auth/logout"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("JSESSIONID", 0));
+    }
+}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package com.ita.challenges.account.infrastructure.config;
 
 import com.ita.challenges.account.domain.port.out.TicketRepository;
+import com.ita.challenges.account.domain.port.out.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,7 +34,12 @@ class SecurityConfigTest {
  private ClientRegistrationRepository clientRegistrationRepository;
 
  @MockBean
+ private UserRepository userRepository;
+
+ @MockBean
  private TicketRepository ticketRepository;
+
+
 
  @Test
  @DisplayName("Should assure the SecurityFilterChain is loaded")


### PR DESCRIPTION
## Description
This PR addresses the testing requirements for the secure logout feature. The actual logout configuration (returning 200 OK and invalidating `JSESSIONID`) was already implemented in the `SecurityConfig` class during previous updates. 

This PR introduces the required `LogoutIntegrationTest` using `MockMvc` to formally verify that the logout endpoint behaves as expected.

## Changes Made
* Added `LogoutIntegrationTest.java`.
* Implemented `testSuccessfulLogoutInvalidatesSession()` to simulate an authenticated request to `/api/account/auth/logout`.
* Asserted that the response status is `200 OK` (no redirection).
* Asserted that the `JSESSIONID` cookie is successfully invalidated (Max-Age = 0).

## Related Issue
Relates to #967