### PR TITLE
feat(challenge): auto-populate editForm with challenge data on init #942

### DIFF
--- a/frontend/src/app/features/challenges/challenges.routes.ts
+++ b/frontend/src/app/features/challenges/challenges.routes.ts
@@ -12,7 +12,7 @@ export const CHALLENGES_ROUTES: Routes = [
     component: ChallengesListPage,
   },
   {
-    path: 'edit',
+    path: 'edit/:id',
     component: EditChallengePage,
   },
   {

--- a/frontend/src/app/features/challenges/pages/edit-challenge-page/edit-challenge-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/edit-challenge-page/edit-challenge-page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditChallengePage } from './edit-challenge-page';
 import { ChallengeService } from '../../services/challenge.service';
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { ReactiveFormsModule } from '@angular/forms';
 
@@ -10,20 +10,30 @@ describe('EditChallengePage', () => {
   let fixture: ComponentFixture<EditChallengePage>;
   let mockChallengeService: any;
   let mockRouter: any;
+  let mockActivatedRoute: any;
 
   beforeEach(async () => {
     mockChallengeService = {
-      update: vi.fn().mockReturnValue(of({}))
+      update: vi.fn().mockReturnValue(of({})),
+      getById: vi.fn().mockReturnValue(of(undefined))
     };
     mockRouter = {
       navigate: vi.fn()
+    };
+    mockActivatedRoute = {
+      snapshot: {
+        paramMap: {
+          get: vi.fn().mockReturnValue(null)
+        }
+      }
     };
 
     await TestBed.configureTestingModule({
       imports: [EditChallengePage, ReactiveFormsModule],
       providers: [
         { provide: ChallengeService, useValue: mockChallengeService },
-        { provide: Router, useValue: mockRouter }
+        { provide: Router, useValue: mockRouter },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute }
       ]
     }).compileComponents();
 
@@ -37,7 +47,6 @@ describe('EditChallengePage', () => {
   });
 
   it('should call challengeService.update with correct values and navigate', () => {
-
     const testData = { id: '777', title: 'Repte Editat', description: 'Nova descripció', language: 'JAVA', difficulty: 'EASY', solution: 'Placeholder solució' };
 
     component.editForm.setValue(testData);
@@ -54,12 +63,44 @@ describe('EditChallengePage', () => {
       language: 'JAVA'
     });
 
-
     expect(navigateSpy).toHaveBeenCalled();
   });
 
   it('should navigate to /challenges when goChallenges is called', () => {
     component.goChallenges();
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/challenges']);
+  });
+
+  it('should patch the form with challenge data when id is in route', async () => {
+    const mockChallenge = {
+      id: '123', title: 'Test Challenge', description: 'Test description', solution: 'Test solution',  difficulty: 'MEDIUM', language: 'TYPESCRIPT'
+    };
+
+    mockActivatedRoute.snapshot.paramMap.get.mockReturnValue('123');
+    mockChallengeService.getById.mockReturnValue(of(mockChallenge));
+
+    component.ngOnInit();
+
+    expect(mockChallengeService.getById).toHaveBeenCalledWith('123');
+    expect(component.editForm.getRawValue()).toEqual(mockChallenge);
+  });
+
+  it('should not call getById when there is no id in route', () => {
+    mockActivatedRoute.snapshot.paramMap.get.mockReturnValue(null);
+
+    component.ngOnInit();
+
+    expect(mockChallengeService.getById).not.toHaveBeenCalled();
+  });
+
+  it('should not patch the form when getById returns undefined', () => {
+    mockActivatedRoute.snapshot.paramMap.get.mockReturnValue('123');
+    mockChallengeService.getById.mockReturnValue(of(undefined));
+
+    component.ngOnInit();
+
+    expect(component.editForm.getRawValue()).toEqual({
+      id: '', title: '', description: '', solution: '', difficulty: 'EASY', language: ''
+    });
   });
 });

--- a/frontend/src/app/features/challenges/pages/edit-challenge-page/edit-challenge-page.ts
+++ b/frontend/src/app/features/challenges/pages/edit-challenge-page/edit-challenge-page.ts
@@ -1,6 +1,6 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { ChallengeService } from '../../services/challenge.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { IChallengeRequest } from '../../models/ichallenge-request.interface';
 import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
@@ -12,10 +12,11 @@ import { ChallengeLanguage } from '../../models/challenge-language.type';
   templateUrl: './edit-challenge-page.html',
   styleUrl: './edit-challenge-page.css',
 })
-export class EditChallengePage {
+export class EditChallengePage implements OnInit {
 
   private readonly challengeService = inject(ChallengeService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   private readonly fb = inject(FormBuilder);
 
   readonly difficulties: ChallengeDifficulty[] = ['EASY', 'MEDIUM', 'HARD'];
@@ -36,6 +37,30 @@ export class EditChallengePage {
     difficulty: ['EASY'],
     language: ['']
   });
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+
+    if (id) {
+      this.challengeService.getById(id).subscribe({
+        next: (challenge) => {
+          if (!challenge) return;
+
+          this.editForm.patchValue({   
+            id:          challenge.id,
+            title:       challenge.title,
+            description: challenge.description,
+            solution:    challenge.solution,
+            difficulty:  challenge.difficulty,
+            language:    challenge.language,
+          });
+        },
+        error: (error) => {
+          console.error('Error loading challenge:', error);
+        }
+      });
+    }
+  }
 
   onSubmit() {
 


### PR DESCRIPTION
Implement auto-population of the reactive form when the user enters the edit screen.

- Inject ActivatedRoute to capture the challenge id from the route params
- Add ngOnInit to fetch the challenge data from the backend via getById()
- Use patchValue to populate the form fields (id, title, description, solution, difficulty, language) with the retrieved data
- Handle the undefined case from the observable to ensure type safety
- Added tests to verify functionality with onInit