### PR TITLE
FEAT [TICKET]: return error message body on invalid create ticket request

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -33,12 +33,15 @@ public class TicketController {
     }
 
     @PostMapping
-    public ResponseEntity<TicketResponse> createTicket(
+    public ResponseEntity<?> createTicket(
             @RequestBody TicketRequest request,
             @AuthenticationPrincipal OAuth2User user) {
 
         if (user == null || user.getAttribute("login") == null) {
             return ResponseEntity.<TicketResponse>status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if (request.title().isBlank() || request.description().isBlank()){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("No empty fields allowed");
         }
 
         String userId = user.getAttribute("login");

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import java.time.Instant;
 import java.util.List;
@@ -76,7 +77,8 @@ class TicketControllerTest {
                         .with(oauth2Login().attributes(attrs -> attrs.put("login", "tester")))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("No empty fields allowed"));
 
     }
 
@@ -114,6 +116,7 @@ class TicketControllerTest {
                 .andExpect(jsonPath("$.title").value("New Title"))
                 .andExpect(jsonPath("$.userId").value(currentUserId));
     }
+
     @Test
     void should_return_404_when_updating_non_existing_ticket() throws Exception {
         String ticketId = "non-existent";

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -68,6 +68,19 @@ class TicketControllerTest {
     }
 
     @Test
+    void should_return_400_when_sending_blank_fields_in_create_ticket() throws Exception {
+        TicketRequest request = new TicketRequest("", "");
+
+        mockMvc.perform(post("/api/account/tickets")
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", "tester")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
     void should_return_200_with_ticket_list_when_requesting_ticket_list() throws Exception {
         Ticket ticket = Ticket.create("testuser", "Login issue", "Unable to access my account");
         when(ticketRepository.findAllByUserId("testuser")).thenReturn(List.of(ticket));


### PR DESCRIPTION
## Summary

Modified createTicket in TicketController to return the validation error message in the response body when the request contains blank title or description fields.
Changed the return type from ResponseEntity<TicketResponse> to ResponseEntity<?> to allow returning a plain text error message.

## Test coverage:
Added/updated test should_return_400_when_sending_blank_fields_in_create_ticket in TicketControllerTest to verify that:

When a TicketRequest with blank title and description is sent to POST /api/account/tickets
The endpoint returns HTTP 400 Bad Request status
The response body contains the error message "request vacia"
