### PR TITLE
feat(auth): redirect user to challenges after authentication

### DIFF
--- a/frontend/src/app/layout/components/header/header.spec.ts
+++ b/frontend/src/app/layout/components/header/header.spec.ts
@@ -6,6 +6,7 @@ import { AuthUser } from '../../../features/auth/models/auth-user.model';
 import { of } from 'rxjs';
 import { AuthService } from '../../../features/auth/data-access/auth-service';
 import { Role } from '../../../core/models/role.enum';
+import { Router } from '@angular/router';
 
 const MOCK_USER: AuthUser = {
   username: 'mockUser',
@@ -15,7 +16,6 @@ const MOCK_USER: AuthUser = {
 };
 
 describe('Header', () => {
-
   let component: Header;
   let fixture: ComponentFixture<Header>;
   let authServiceMock: {
@@ -25,6 +25,9 @@ describe('Header', () => {
     getUser: ReturnType<typeof vi.fn>;
     setUser: ReturnType<typeof vi.fn>;
   };
+  let routerMock: {
+    navigate: ReturnType<typeof vi.fn>;
+  };
   beforeEach(async () => {
     authServiceMock = {
       user: signal(null),
@@ -33,13 +36,16 @@ describe('Header', () => {
       getUser: vi.fn().mockReturnValue(null),
       setUser: vi.fn(),
     };
+    routerMock = {
+      navigate: vi.fn(),
+    };
     await TestBed.configureTestingModule({
       imports: [Header],
       providers: [
         { provide: AuthService, useValue: authServiceMock },
+        { provide: Router, useValue: routerMock },
       ],
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(Header);
     component = fixture.componentInstance;
@@ -54,12 +60,9 @@ describe('Header', () => {
   });
 
   it('should render logout button', () => {
-
-    const logoutButton =
-      fixture.nativeElement.querySelector('app-logout-button');
+    const logoutButton = fixture.nativeElement.querySelector('app-logout-button');
 
     expect(logoutButton).toBeTruthy();
-
   });
 
   it('should show username when user is logged in', () => {
@@ -68,7 +71,7 @@ describe('Header', () => {
 
     const h4s = fixture.nativeElement.querySelectorAll('h4');
     const usernameEl = Array.from(h4s).find((el: any) =>
-      el.textContent.includes(MOCK_USER.username)
+      el.textContent.includes(MOCK_USER.username),
     );
     expect(usernameEl).toBeTruthy();
   });
@@ -108,5 +111,23 @@ describe('Header', () => {
     authServiceMock.user.set({ ...MOCK_USER, role: undefined });
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('h4').textContent).toContain('CONVIDAT');
+  });
+
+  it('should redirect to challenges after fetching authenticated user', () => {
+    authServiceMock.fetchUser.mockReturnValue(of(MOCK_USER));
+
+    component.ngOnInit();
+
+    expect(authServiceMock.setUser).toHaveBeenCalledWith(MOCK_USER);
+    expect(routerMock.navigate).toHaveBeenCalledWith(['/challenges']);
+  });
+
+  it('should not redirect when user already exists', () => {
+    authServiceMock.getUser.mockReturnValue(MOCK_USER);
+
+    component.ngOnInit();
+
+    expect(authServiceMock.fetchUser).not.toHaveBeenCalled();
+    expect(routerMock.navigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/layout/components/header/header.ts
+++ b/frontend/src/app/layout/components/header/header.ts
@@ -1,4 +1,5 @@
 import { Component, computed, inject, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { LogoutButton } from '../../../shared/components/logout-button/logout-button';
 import { AuthService } from '../../../features/auth/data-access/auth-service';
 
@@ -8,8 +9,9 @@ import { AuthService } from '../../../features/auth/data-access/auth-service';
   templateUrl: './header.html',
   styleUrl: './header.css',
 })
-export class Header implements OnInit{
+export class Header implements OnInit {
   private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
 
   public user = computed(() => this.authService.user());
 
@@ -17,7 +19,10 @@ export class Header implements OnInit{
     if (this.authService.getUser()) return;
 
     this.authService.fetchUser().subscribe({
-      next: (user) => this.authService.setUser(user),
+      next: (user) => {
+        this.authService.setUser(user);
+        this.router.navigate(['/challenges']);
+      },
     });
   }
 }


### PR DESCRIPTION
## Description

- Added redirect to the challenges page after successful authentication.
- Ensured authenticated users are redirected when a session is restored.
- Verified navigation flow does not produce routing errors.

### Out of Scope
End-to-end validation of the GitHub OAuth flow depends on backend authentication configuration and callback handling.