### PR TITLE
feat(challenge-detail): add programming mode with role-based start button #928

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -1,20 +1,32 @@
 
+<app-role-selector
+    (roleChange)="onRoleChange($event)"
+></app-role-selector>
+
 @if (challenge(); as ch) {
   <h1>{{ ch.title }}</h1>
   <p>{{ ch.description }}</p>
   <p>Dificultat: {{ getDifficultyLabel(ch.difficulty) }}</p>
   <p>Llenguatge: {{ getLanguageLabel(ch.language) }}</p>
-    
-  <form [formGroup]="codeSolutionForm" (ngSubmit)="saveSolution()">
-    <textarea
-        id="challengeAnswer"
-        formControlName="code"
-        rows="10"
-        placeholder="Escriu aquí la resposta del repte...">
-      </textarea>
+
+
+  @if (!isMentor()) {
     <div class="challenge__actions">
-      <button type="submit">Guardar</button>
-      <button type="button" (click)="publishSolution()">Publicar</button>
+      <button type="button" (click)="setProgrammingMode()">Començar repte</button>
     </div>
-  </form>
+    @if (programmingMode()) {
+      <form [formGroup]="codeSolutionForm" (ngSubmit)="saveSolution()">
+        <textarea
+            id="challengeAnswer"
+            formControlName="code"
+            rows="10"
+            placeholder="Escriu aquí la resposta del repte...">
+          </textarea>
+        <div class="challenge__actions">
+          <button type="submit">Guardar</button>
+          <button type="button" (click)="publishSolution()">Publicar</button>
+        </div>
+      </form>
+    }
+  }
 }

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -98,4 +98,13 @@ describe('ChallengeDetailPage', () => {
     });
   });
 
+  it('should set isMentor signal with the received value', () => {
+    component.onRoleChange(true);
+    expect(component.isMentor()).toBe(true);
+  });
+
+  it('should set programmingMode signal to true', () => {
+    component.setProgrammingMode();
+    expect(component.programmingMode()).toBe(true);
+  });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -9,6 +9,7 @@ import { AuthService } from '../../../auth/data-access/auth-service';
 import { IChallengeSubmission } from '../../models/ichallenge-submission.interface';
 import { ChallengeLanguage } from '../../models/challenge-language.type';
 import { ChallengeDifficulty } from '../../models/challenge-difficulty.type';
+import { RoleSelectorComponent } from '../../components/role-selector/role-selector';
 
 interface AuthUserWithId extends AuthUser {
   id: string;
@@ -16,7 +17,7 @@ interface AuthUserWithId extends AuthUser {
 
 @Component({
   selector: 'app-challenge-detail-page',
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, RoleSelectorComponent],
   templateUrl: './challenge-detail-page.html',
   styleUrl: './challenge-detail-page.css',
 })
@@ -28,6 +29,8 @@ export class ChallengeDetailPage {
   private readonly authService = inject(AuthService)
 
   challenge = signal<IChallenge | undefined>(undefined);
+  isMentor = signal(false);
+  programmingMode = signal(false);
 
   languageLabels: Record<ChallengeLanguage, string> = {
     JAVA: 'Java',
@@ -103,4 +106,13 @@ export class ChallengeDetailPage {
       });
     }
   }
+
+  onRoleChange(value: boolean): void {
+    this.isMentor.set(value);
+  }
+
+  setProgrammingMode(): void {
+    this.programmingMode.set(true);
+  }
+
 }


### PR DESCRIPTION
## Description

Reuses the existing `challenge-detail` component to activate a "programming mode" that unlocks the solution textarea when the student starts the challenge flow, avoiding the creation of a new screen.

## Changes

- Added `isMentor` signal and integrated `RoleSelectorComponent` to simulate role-based visibility
- Added `programmingMode` signal activated by a "Començar repte" button, visible only to student users
- Conditionally renders the solution `<textarea>` and form using `@if (programmingMode())`
- Conditionally displays "Guardar" and "Publicar" action buttons once programming mode is active
- Added `onRoleChange()` and `setProgrammingMode()` methods
- `codeSolutionForm`, `saveSolution()` and `publishSolution()` wired up for future HTTP integration
- Added unit tests for `onRoleChange()` and `setProgrammingMode()`

## Not included

Advanced styling, code editor integration (Monaco/CodeMirror), HTTP request implementation, and logic for the Save and Finish actions — these will be addressed in later subtasks.
