### PR TITLE
enabling official response from backend

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -25,9 +25,9 @@ public class SubmissionController {
     private final SubmissionRepository submissionRepository;
     private final ChallengeRepository challengeRepository;
 
-    public SubmissionController(SaveDraftSubmissionUseCase saveDraftSubmissionUseCase, SubmissionRepository submissionrepository, ChallengeRepository challengeRepository) {
+    public SubmissionController(SaveDraftSubmissionUseCase saveDraftSubmissionUseCase, SubmissionRepository submissionRepository, ChallengeRepository challengeRepository) {
         this.saveDraftSubmissionUseCase = saveDraftSubmissionUseCase;
-        this.submissionRepository = submissionrepository;
+        this.submissionRepository = submissionRepository;
         this.challengeRepository = challengeRepository;
     }
 

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionController.java
@@ -1,5 +1,6 @@
 package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.controller;
 
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
@@ -9,23 +10,25 @@ import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionR
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
 import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.ExistsFinalSubmissionResponse;
 import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.FinalizeSubmissionRequest;
-import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
 import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.SaveDraftSubmissionRequest;
+import com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto.SubmissionResultResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 
 @RestController
 @RequestMapping("/api/challenge/submissions")
 public class SubmissionController {
 
     private final SaveDraftSubmissionUseCase saveDraftSubmissionUseCase;
-    private final SubmissionRepository repository;
+    private final SubmissionRepository submissionRepository;
+    private final ChallengeRepository challengeRepository;
 
-    public SubmissionController(SaveDraftSubmissionUseCase saveDraftSubmissionUseCase, SubmissionRepository repository) {
+    public SubmissionController(SaveDraftSubmissionUseCase saveDraftSubmissionUseCase, SubmissionRepository submissionrepository, ChallengeRepository challengeRepository) {
         this.saveDraftSubmissionUseCase = saveDraftSubmissionUseCase;
-        this.repository = repository;
+        this.submissionRepository = submissionrepository;
+        this.challengeRepository = challengeRepository;
     }
 
     @PostMapping
@@ -40,16 +43,30 @@ public class SubmissionController {
     }
 
     @PostMapping("/submit")
-    public ResponseEntity<Void> finalize(@RequestBody FinalizeSubmissionRequest request) {
+    public ResponseEntity<SubmissionResultResponse> finalize(@RequestBody FinalizeSubmissionRequest request){
         Submission finalSubmission = Submission.createSubmitted(
                 SubmissionId.generate(),
                 ChallengeId.of(request.challengeId()),
                 UserId.of(request.userId()),
                 request.code()
         );
-        repository.save(finalSubmission);
+        submissionRepository.save(finalSubmission);
 
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        Challenge challenge = challengeRepository.find(ChallengeId.of(request.challengeId()));
+
+        String officialSolution = request.revealOfficialSolution()
+                ? challenge.getSolution().toString()
+                : null;
+
+        SubmissionResultResponse response = new SubmissionResultResponse(
+                finalSubmission.getId().toString(),
+                request.code(),
+                challenge.getTitle().toString(),
+                officialSolution,
+                request.revealOfficialSolution()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping("/finalized")
@@ -57,7 +74,7 @@ public class SubmissionController {
             @RequestParam String userId,
             @RequestParam String challengeId
     ) {
-        boolean exists = repository.existsFinalSubmission(UserId.of(userId), ChallengeId.of(challengeId));
+        boolean exists = submissionRepository.existsFinalSubmission(UserId.of(userId), ChallengeId.of(challengeId));
         return ResponseEntity.status(HttpStatus.OK).body(new ExistsFinalSubmissionResponse(exists));
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/FinalizeSubmissionRequest.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/FinalizeSubmissionRequest.java
@@ -1,3 +1,3 @@
 package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
 
-public record FinalizeSubmissionRequest(String challengeId, String userId, String code) {}
+public record FinalizeSubmissionRequest(String challengeId, String userId, String code, boolean revealOfficialSolution) {}

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/SubmissionResultResponse.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/dto/SubmissionResultResponse.java
@@ -1,0 +1,8 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.dto;
+
+public record SubmissionResultResponse(  String submissionId,
+                                        String studentCode,
+                                        String challengeTitle,
+                                        String officialSolution,
+                                        boolean revealedSolution) {
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/in/web/controller/SubmissionControllerTest.java
@@ -1,6 +1,11 @@
 package com.itachallenges.challengeservice.submission.infrastructure.adapter.in.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.submission.application.dto.SaveDraftSubmissionCommand;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
 import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
@@ -39,6 +44,9 @@ class SubmissionControllerTest {
 
     @MockBean
     private SubmissionRepository submissionRepository;
+
+    @MockBean
+    private ChallengeRepository challengeRepository;
 
     @Test
     void shouldSubmitSuccessfully() throws Exception {
@@ -114,12 +122,31 @@ class SubmissionControllerTest {
     void shouldFinalizeSubmissionSuccessfully() throws Exception {
         String challengeId = UUID.randomUUID().toString();
         String userId = UUID.randomUUID().toString();
+
+        Challenge mockChallenge = Challenge.restore(
+                ChallengeId.of(challengeId),
+                "Challenge Title",
+                "Description",
+                ChallengeLanguage.JAVASCRIPT,
+                ChallengeDifficulty.EASY,
+                "official solution"
+        );
+
         FinalizeSubmissionRequest request = new FinalizeSubmissionRequest(
-                challengeId, userId, "my solution");
+                challengeId, userId, "my solution", true);
+
+        when(challengeRepository.find(any(ChallengeId.class))).thenReturn(mockChallenge);
+        when(submissionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
         mockMvc.perform(post("/api/challenge/submissions/submit")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.submissionId").exists())
+                .andExpect(jsonPath("$.studentCode").value("my solution"))
+                .andExpect(jsonPath("$.challengeTitle").value("Challenge Title"))
+                .andExpect(jsonPath("$.officialSolution").value("official solution"))
+                .andExpect(jsonPath("$.revealedSolution").value(true));
     }
 
 


### PR DESCRIPTION
This PR adds the next changes in the backend:

- Adds a new record/DTO called SubmissionResultResponse that sends the official response to the backend from the frontend.
- A new parameter (boolean revealOfficialResponse) has been added to FinalizeSubmisionRequest, a record/DTO that already existed.
- SubmissionController has been updated with a new version of the finalize method; now instead of returning to the backend a void as a confirmation of the PostMapping, it returns the solution through the new RecordDTO (SubmissionResultResponse).

Since I am working in parallel with my partners, the first commit will be a draft since it is possible that small changes and a new commit would be needed to adjust the files to the new changes. Suggestions and corrections are more than welcomed.