### PR TITLE
feat(challenge): show official solution after publishing submission #930

### DIFF
--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -5,7 +5,7 @@
     <div class="challenge-header">
       <h1 class="challenge-title">{{ ch.title }}</h1>
       <p class="challenge-description">{{ ch.description }}</p>
-      
+
       <div class="challenge-meta">
         <div class="meta-tag">
           <span class="meta-label">Dificultat: </span>
@@ -38,6 +38,12 @@
               <button type="button" class="btn btn-primary" (click)="publishSolution()">Publicar</button>
             </div>
           </form>
+        }
+        @if (solutionRevealed()) {
+          <div class="challenge__result">
+            <h2>Solució oficial</h2>
+            <textarea rows="10" readonly>{{ challenge()?.solution }}</textarea>
+          </div>
         }
       }
     </div>

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -5,7 +5,7 @@
     <div class="challenge-header">
       <h1 class="challenge-title">{{ ch.title }}</h1>
       <p class="challenge-description">{{ ch.description }}</p>
-
+     
       <div class="challenge-meta">
         <div class="meta-tag">
           <span class="meta-label">Dificultat: </span>

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.html
@@ -5,7 +5,7 @@
     <div class="challenge-header">
       <h1 class="challenge-title">{{ ch.title }}</h1>
       <p class="challenge-description">{{ ch.description }}</p>
-     
+      
       <div class="challenge-meta">
         <div class="meta-tag">
           <span class="meta-label">Dificultat: </span>

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.spec.ts
@@ -107,4 +107,14 @@ describe('ChallengeDetailPage', () => {
     component.setProgrammingMode();
     expect(component.programmingMode()).toBe(true);
   });
+
+  it('should show solution section when solutionRevealed is true', async () => {
+    fixture.detectChanges();
+    component.solutionRevealed.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const result = fixture.nativeElement.querySelector('.challenge__result');
+    expect(result).toBeTruthy();
+  });
 });

--- a/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenge-detail-page/challenge-detail-page.ts
@@ -31,6 +31,7 @@ export class ChallengeDetailPage {
   challenge = signal<IChallenge | undefined>(undefined);
   isMentor = signal(false);
   programmingMode = signal(false);
+  solutionRevealed = signal(false);
 
   languageLabels: Record<ChallengeLanguage, string> = {
     JAVA: 'Java',
@@ -99,6 +100,7 @@ export class ChallengeDetailPage {
       this.challengeApiService.publishSolution(challengeSolution).subscribe({
         next: () => {
           alert('Solució publicada!');
+          this.solutionRevealed.set(true);
         },
         error: (err) => {
           console.error('Error en publicar la solució:', err);


### PR DESCRIPTION
**Show official solution after publishing submission**

Displays the official solution in a readonly textarea once the student publishes their submission. A `solutionRevealed` signal is set to `true` on successful publish, which controls the visibility of the solution block in the template. The solution value is read directly from the existing `challenge` signal.

**Out of scope**
- No unit tests added, as the change is purely presentational with no logic involved.