### PR TITLE
feat(tickets): show backend response feedback on ticket creation and add tests #995

### DIFF
--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.css
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.css
@@ -1,8 +1,8 @@
-.error-message {
-  color: #d32f2f;
-  background-color: #ffebee;
+.message {
+  display: flex;
+  width: fit-content;
   padding: 12px;
   border-radius: 4px;
-  margin-bottom: 16px;
+  margin: 16px 0;
   border: 1px solid #ef9a9a;
 }

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.html
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.html
@@ -1,9 +1,4 @@
 <form [formGroup]="ticketForm" (ngSubmit)="onSubmit()">
-  @if (errorMessage) {
-  <div class="error-message">
-    {{ errorMessage }}
-  </div>
-  }
   <div>
     <label for="title">Títol</label>
     <input type="text" id="title" formControlName="title">
@@ -14,3 +9,9 @@
   </div>
   <button type="submit">Crear</button>
 </form>
+
+@if (ticketMessage()) {
+  <div class="message">
+    <p>{{ ticketMessage() }}</p>
+  </div>
+}

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateTicketPage } from './create-ticket-page';
 import { TicketApiService } from '../../data-access/ticket-api.service';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { Router } from '@angular/router';
 import { TicketStatus } from '../../models/status.enum';
 
@@ -34,6 +34,10 @@ describe('CreateTicketPage', () => {
     await fixture.whenStable();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should call ticketApiService.create when call onSubmit with correct data', () => {
     const testData = { title: 'Nou Repte', description: 'Descripció' };
     component.ticketForm.setValue(testData);
@@ -42,10 +46,27 @@ describe('CreateTicketPage', () => {
     expect(mockTicketService.create).toHaveBeenCalledWith(testData);
   });
 
-  it('should navigate to /tickets when ticketApiService.create emits next', () => {
+  it('should show the success message on 201 and navigate to /tickets after the delay', () => {
+    vi.useFakeTimers();
     const testData = { title: 'Nou Repte', description: 'Descripció' };
     component.ticketForm.setValue(testData);
     component.onSubmit();
+
+    expect(component.ticketMessage()).toBe('Ticket creat correctament');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/tickets']);
+  });
+
+  it('should show the "dades incorrectes" message on a 400 error and not navigate', () => {
+    vi.spyOn(mockTicketService, 'create').mockReturnValue(throwError(() => ({ status: 400 })));
+    const testData = { title: '', description: '' };
+    component.ticketForm.setValue(testData);
+    component.onSubmit();
+
+    expect(component.ticketMessage()).toBe('Dades del ticket incorrectes');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
@@ -46,16 +46,10 @@ describe('CreateTicketPage', () => {
     expect(mockTicketService.create).toHaveBeenCalledWith(testData);
   });
 
-  it('should show the success message on 201 and navigate to /tickets after the delay', () => {
-    vi.useFakeTimers();
+  it('should navigate to /tickets after the succes', () => {
     const testData = { title: 'Nou Repte', description: 'Descripció' };
     component.ticketForm.setValue(testData);
     component.onSubmit();
-
-    expect(component.ticketMessage()).toBe('Ticket creat correctament');
-    expect(mockRouter.navigate).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(2000);
 
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/tickets']);
   });

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.spec.ts
@@ -46,7 +46,7 @@ describe('CreateTicketPage', () => {
     expect(mockTicketService.create).toHaveBeenCalledWith(testData);
   });
 
-  it('should navigate to /tickets after the succes', () => {
+  it('should navigate to /tickets after the success', () => {
     const testData = { title: 'Nou Repte', description: 'Descripció' };
     component.ticketForm.setValue(testData);
     component.onSubmit();

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectorRef } from '@angular/core';
+import { Component, inject, signal, DestroyRef } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { ITicketRequest } from '../../models/iticket-request.interface';
@@ -11,33 +11,47 @@ import { Router } from '@angular/router';
   styleUrl: './create-ticket-page.css',
 })
 export class CreateTicketPage {
-  private readonly cdr = inject(ChangeDetectorRef);
-  readonly ticketService = inject(TicketApiService)
-  readonly fb = inject(FormBuilder)
-  readonly router = inject(Router)
+  readonly ticketService = inject(TicketApiService);
+  readonly fb = inject(FormBuilder);
+  readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
-  errorMessage: string | null = null;
+  readonly ticketMessage = signal<string>('');
 
   ticketForm = this.fb.group({
     title: [''],
     description: ['']
-  })
+  });
 
   onSubmit() {
-    this.errorMessage = null;
+    this.ticketMessage.set('');
 
-    const newTicket = this.ticketForm.value as ITicketRequest
+    const newTicket = this.ticketForm.value as ITicketRequest;
 
     this.ticketService.create(newTicket).subscribe({
-      next: () => {this.goTickets();},
+      next: () => {
+        this.ticketMessage.set('Ticket creat correctament');
+        const redirectId = setTimeout(() => this.goTickets(), 2000);
+        this.destroyRef.onDestroy(() => clearTimeout(redirectId));
+      },
       error: (err) => {
-        this.errorMessage = 'Error al crear el ticket: ' + err.error;
-        this.cdr.detectChanges();
+        this.ticketMessage.set(this.getMessageForStatus(err.status));
       }
     });
   }
 
   goTickets() {
     this.router.navigate(['/tickets']);
-  }    
+  }
+
+  private getMessageForStatus(status: number): string {
+    switch (status) {
+      case 400:
+        return 'Dades del ticket incorrectes';
+      case 403:
+        return 'No tens permís per crear aquest tiquet';
+      default:
+        return "Error en crear el ticket";
+    }
+  }
 }

--- a/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
+++ b/frontend/src/app/features/tickets/pages/create-ticket-page/create-ticket-page.ts
@@ -1,5 +1,5 @@
-import { Component, inject, signal, DestroyRef } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { ITicketRequest } from '../../models/iticket-request.interface';
 import { Router } from '@angular/router';
@@ -14,7 +14,6 @@ export class CreateTicketPage {
   readonly ticketService = inject(TicketApiService);
   readonly fb = inject(FormBuilder);
   readonly router = inject(Router);
-  private readonly destroyRef = inject(DestroyRef);
 
   readonly ticketMessage = signal<string>('');
 
@@ -29,11 +28,7 @@ export class CreateTicketPage {
     const newTicket = this.ticketForm.value as ITicketRequest;
 
     this.ticketService.create(newTicket).subscribe({
-      next: () => {
-        this.ticketMessage.set('Ticket creat correctament');
-        const redirectId = setTimeout(() => this.goTickets(), 2000);
-        this.destroyRef.onDestroy(() => clearTimeout(redirectId));
-      },
+      next: () => {this.goTickets();},
       error: (err) => {
         this.ticketMessage.set(this.getMessageForStatus(err.status));
       }


### PR DESCRIPTION
## Description

Add a non-blocking message below the create-ticket form to inform the user how the creation process ended (success, validation error, permission error or unexpected error), based on the HTTP status returned by the backend.

- Replace errorMessage property and ChangeDetectorRef with a ticketMessage signal, removing the need for manual change detection
- Map HTTP status codes to user-facing messages (201, 400, 403, default) 
- Delay navigation to /tickets by 2s on success so the message is readable, clearing the timeout on component destroy
- Add tests covering the success message/navigation flow and the 400 error message

## Outside of this PR

- No tests have been added for the 403 error case or the generic error message; only 201 and 400 tests are covered as a proof of concept for the pattern. These can be added in a follow-up commit/PR using the same approach.
- No visual styling is applied to the message (plain text, as requested for this phase); the final design (colors, icons, position, entry/exit animation, etc.) is left for future tasks.