### PR TITLE
[CHALLENGE] Create filter method in the Backend

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -2,12 +2,14 @@ package com.itachallenges.challengeservice.catalog.domain.port.out;
 
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 
 import java.util.List;
 
 public interface ChallengeRepository {
 
     List<Challenge> findAll();
+    List<Challenge> findByLanguage(ChallengeLanguage language);
     Challenge update(Challenge challenge);
     Challenge save(Challenge challenge);
     void delete(ChallengeId id);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeResponse;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
 import lombok.AllArgsConstructor;
@@ -39,14 +40,24 @@ public class ChallengeController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ChallengeResponse>> findAll() {
-        List<ChallengeResponse> challenges = repository.findAll()
-                .stream()
-                .map(c -> new ChallengeResponse(c.getId().toString(), c.getTitle().toString(), c.getDescription().toString(), c.getLanguage(), c.getDifficulty(), c.getSolution().toString()))
-                .toList();
-        return ResponseEntity.ok(challenges);
-    }
+    public ResponseEntity<List<ChallengeResponse>> findAll(
+            @RequestParam(required = false) ChallengeLanguage language
+    ) {
+        List<Challenge> challenges = (language == null)
+                ? repository.findAll()
+                : repository.findByLanguage(language);
 
+        List<ChallengeResponse> response = challenges.stream()
+                .map(c -> new ChallengeResponse(
+                        c.getId().toString(),
+                        c.getTitle().toString(),
+                        c.getDescription().toString(),
+                        c.getLanguage(),
+                        c.getDifficulty(),
+                        c.getSolution().toString()))
+                .toList();
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<ChallengeResponse> find(@PathVariable String id) {
@@ -68,7 +79,6 @@ public class ChallengeController {
         repository.delete(ChallengeId.of(id));
         return ResponseEntity.noContent().build();
     }
-
 
     @PutMapping("/{id}")
     public ResponseEntity<ChallengeResponse> update(

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -3,6 +3,7 @@ package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.ou
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
@@ -20,18 +21,14 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
 
     @Override
     public Challenge save(Challenge challenge) {
-        try{
-            storage.put(challenge.getId(), challenge);
-            return challenge;
-        }catch(RuntimeException e){ throw new RuntimeException("Error saving challenge" + e.getMessage());}
-
+        storage.put(challenge.getId(), challenge);
+        return challenge;
     }
 
     @Override
     public Challenge update(Challenge challenge) {
         ChallengeId id = challenge.getId();
         ensureChallengeExists(id);
-
 
         storage.put(id, challenge);
         return challenge;
@@ -56,11 +53,16 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
         return new ArrayList<>(storage.values());
     }
 
+    @Override
+    public List<Challenge> findByLanguage(ChallengeLanguage language) {
+        return storage.values().stream()
+                .filter(c -> c.getLanguage() == language)
+                .toList();
+    }
+
     private void ensureChallengeExists(ChallengeId id) {
         if (!storage.containsKey(id)) {
             throw new NoSuchElementException("Challenge not found with id: " + id);
         }
     }
-
-
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -21,8 +21,11 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
 
     @Override
     public Challenge save(Challenge challenge) {
-        storage.put(challenge.getId(), challenge);
-        return challenge;
+        try{
+            storage.put(challenge.getId(), challenge);
+            return challenge;
+        }catch(RuntimeException e){ throw new RuntimeException("Error saving challenge" + e.getMessage());}
+
     }
 
     @Override

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
@@ -1,0 +1,45 @@
+package com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.out.persistence;
+
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryChallengeRepositoryFilterTest {
+
+    private InMemoryChallengeRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new InMemoryChallengeRepository();
+    }
+
+    @Test
+    void should_return_only_challenges_with_given_language() {
+        Challenge java1 = Challenge.create("Java 1", "Desc 1", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol 1");
+        Challenge java2 = Challenge.create("Java 2", "Desc 2", ChallengeLanguage.JAVA, ChallengeDifficulty.MEDIUM, "Sol 2");
+        Challenge python = Challenge.create("Python 1", "Desc 3", ChallengeLanguage.PYTHON, ChallengeDifficulty.HARD, "Sol 3");
+        repository.save(java1);
+        repository.save(java2);
+        repository.save(python);
+
+        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.JAVA);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Challenge::getLanguage).containsOnly(ChallengeLanguage.JAVA);
+    }
+
+    @Test
+    void should_return_empty_list_when_no_challenges_match_language() {
+        repository.save(Challenge.create("Java only", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol"));
+
+        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.PYTHON);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -61,9 +61,10 @@ class InMemoryChallengeRepositoryTest {
     }
 
     @Test
-    void should_throw_NullPointerException_when_saving_null_challenge() {
+    void should_throw_RuntimeException_when_any_error_occurs_during_save(){
         assertThatThrownBy(() -> repository.save(null))
-                .isInstanceOf(NullPointerException.class);
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error saving challenge");
     }
 
     @Test

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -12,7 +12,6 @@ import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class InMemoryChallengeRepositoryTest {
 
@@ -28,7 +27,6 @@ class InMemoryChallengeRepositoryTest {
     @Test
     void should_return_empty_list_when_no_challenges_exist() {
         List<Challenge> result = repository.findAll();
-
         assertThat(result).isEmpty();
     }
 
@@ -37,9 +35,9 @@ class InMemoryChallengeRepositoryTest {
         Challenge newChallenge = Challenge.create("New Challenge Title", "New Challenge Description", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "New Challenge Solution");
         Challenge result = repository.save(newChallenge);
 
-        assertThat(result.getTitle().toString()).isEqualTo("New Challenge Title");
-        assertThat(result.getDescription().toString()).isEqualTo("New Challenge Description");
-        assertThat(result.getSolution().toString()).isEqualTo("New Challenge Solution");
+        assertThat(result.getTitle()).hasToString("New Challenge Title");
+        assertThat(result.getDescription()).hasToString("New Challenge Description");
+        assertThat(result.getSolution()).hasToString("New Challenge Solution");
     }
 
     @Test
@@ -57,26 +55,22 @@ class InMemoryChallengeRepositoryTest {
 
         Challenge result = repository.update(updated);
 
-        assertThat(result.getTitle().toString()).isEqualTo("New title");
-        assertThat(result.getDescription().toString()).isEqualTo("New description");
-        assertThat(result.getSolution().toString()).isEqualTo("New solution");
+        assertThat(result.getTitle()).hasToString("New title");
+        assertThat(result.getDescription()).hasToString("New description");
+        assertThat(result.getSolution()).hasToString("New solution");
     }
 
     @Test
-    void should_throw_RuntimeException_when_any_error_occurs_during_save(){
+    void should_throw_NullPointerException_when_saving_null_challenge() {
         assertThatThrownBy(() -> repository.save(null))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Error saving challenge");
+                .isInstanceOf(NullPointerException.class);
     }
-
-
 
     @Test
     void should_delete_existing_challenge() {
-        Challenge challenge = Challenge.create("To be deleted", "Description", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Solution");
-
-        ChallengeId id = challenge.getId();
-        repository.save(challenge);
+        Challenge challengeToDelete = Challenge.create("To be deleted", "Description", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Solution");
+        ChallengeId id = challengeToDelete.getId();
+        repository.save(challengeToDelete);
         assertThat(repository.findAll()).hasSize(1);
 
         repository.delete(id);
@@ -119,6 +113,28 @@ class InMemoryChallengeRepositoryTest {
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessageContaining("Challenge not found with id: " + nonExistentId);
     }
+
+    @Test
+    void should_return_only_challenges_with_given_language() {
+        Challenge java1 = Challenge.create("Java 1", "Desc 1", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol 1");
+        Challenge java2 = Challenge.create("Java 2", "Desc 2", ChallengeLanguage.JAVA, ChallengeDifficulty.MEDIUM, "Sol 2");
+        Challenge python = Challenge.create("Python 1", "Desc 3", ChallengeLanguage.PYTHON, ChallengeDifficulty.HARD, "Sol 3");
+        repository.save(java1);
+        repository.save(java2);
+        repository.save(python);
+
+        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.JAVA);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Challenge::getLanguage).containsOnly(ChallengeLanguage.JAVA);
+    }
+
+    @Test
+    void should_return_empty_list_when_no_challenges_match_language() {
+        repository.save(Challenge.create("Java only", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol"));
+
+        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.PYTHON);
+
+        assertThat(result).isEmpty();
+    }
 }
-
-

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryTest.java
@@ -114,28 +114,4 @@ class InMemoryChallengeRepositoryTest {
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessageContaining("Challenge not found with id: " + nonExistentId);
     }
-
-    @Test
-    void should_return_only_challenges_with_given_language() {
-        Challenge java1 = Challenge.create("Java 1", "Desc 1", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol 1");
-        Challenge java2 = Challenge.create("Java 2", "Desc 2", ChallengeLanguage.JAVA, ChallengeDifficulty.MEDIUM, "Sol 2");
-        Challenge python = Challenge.create("Python 1", "Desc 3", ChallengeLanguage.PYTHON, ChallengeDifficulty.HARD, "Sol 3");
-        repository.save(java1);
-        repository.save(java2);
-        repository.save(python);
-
-        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.JAVA);
-
-        assertThat(result).hasSize(2);
-        assertThat(result).extracting(Challenge::getLanguage).containsOnly(ChallengeLanguage.JAVA);
-    }
-
-    @Test
-    void should_return_empty_list_when_no_challenges_match_language() {
-        repository.save(Challenge.create("Java only", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol"));
-
-        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.PYTHON);
-
-        assertThat(result).isEmpty();
-    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
@@ -1,0 +1,60 @@
+package com.itachallenges.challengeservice.infrastructure.adapter.web.in.controller;
+
+import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
+import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.controller.ChallengeController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChallengeController.class)
+class ChallengeControllerFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ChallengeRepository repository;
+
+    @Test
+    void should_return_200_with_filtered_list_when_requesting_challenges_by_language() throws Exception {
+        Challenge javaChallenge = Challenge.create(
+                "Java Challenge", "Java description",
+                ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Java solution"
+        );
+        when(repository.findByLanguage(ChallengeLanguage.JAVA)).thenReturn(List.of(javaChallenge));
+
+        mockMvc.perform(get("/api/challenge").param("language", "JAVA"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].title").value("Java Challenge"))
+                .andExpect(jsonPath("$[0].language").value("JAVA"));
+    }
+
+    @Test
+    void should_return_400_when_requesting_challenges_with_invalid_language() throws Exception {
+        mockMvc.perform(get("/api/challenge").param("language", "COBOL"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_200_with_empty_list_when_filter_matches_no_challenges() throws Exception {
+        when(repository.findByLanguage(ChallengeLanguage.SQL)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/challenge").param("language", "SQL"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -138,25 +138,4 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.difficulty").value("EASY"))
                 .andExpect(jsonPath("$.solution").value("Test Solution"));
     }
-
-    @Test
-    void should_return_200_with_filtered_list_when_requesting_challenges_by_language() throws Exception {
-        Challenge javaChallenge = Challenge.create(
-                "Java Challenge", "Java description",
-                ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Java solution"
-        );
-        when(repository.findByLanguage(ChallengeLanguage.JAVA)).thenReturn(List.of(javaChallenge));
-
-        mockMvc.perform(get("/api/challenge").param("language", "JAVA"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].title").value("Java Challenge"))
-                .andExpect(jsonPath("$[0].language").value("JAVA"));
-    }
-
-    @Test
-    void should_return_400_when_requesting_challenges_with_invalid_language() throws Exception {
-        mockMvc.perform(get("/api/challenge").param("language", "COBOL"))
-                .andExpect(status().isBadRequest());
-    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerTest.java
@@ -82,7 +82,7 @@ class ChallengeControllerTest {
     @Test
     void should_update_challenge_and_return_200() throws Exception {
         String id = UUID.randomUUID().toString();
-        ChallengeRequest request = new ChallengeRequest(
+        ChallengeRequest updateRequest = new ChallengeRequest(
                 "Updated title",
                 "Updated description",
                 ChallengeLanguage.JAVA,
@@ -104,7 +104,7 @@ class ChallengeControllerTest {
 
         mockMvc.perform(put("/api/challenge/" + id)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(updateRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id))
                 .andExpect(jsonPath("$.title").value("Updated title"))
@@ -113,7 +113,6 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.language").value("JAVA"))
                 .andExpect(jsonPath("$.solution").value("Updated solution"));
     }
-
 
     @Test
     void should_return_200_with_challenge_when_finding_by_id() throws Exception {
@@ -138,5 +137,26 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.language").value("JAVA"))
                 .andExpect(jsonPath("$.difficulty").value("EASY"))
                 .andExpect(jsonPath("$.solution").value("Test Solution"));
+    }
+
+    @Test
+    void should_return_200_with_filtered_list_when_requesting_challenges_by_language() throws Exception {
+        Challenge javaChallenge = Challenge.create(
+                "Java Challenge", "Java description",
+                ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Java solution"
+        );
+        when(repository.findByLanguage(ChallengeLanguage.JAVA)).thenReturn(List.of(javaChallenge));
+
+        mockMvc.perform(get("/api/challenge").param("language", "JAVA"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].title").value("Java Challenge"))
+                .andExpect(jsonPath("$[0].language").value("JAVA"));
+    }
+
+    @Test
+    void should_return_400_when_requesting_challenges_with_invalid_language() throws Exception {
+        mockMvc.perform(get("/api/challenge").param("language", "COBOL"))
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
## Summary

Add an optional `language` query parameter to `GET /api/challenge` to filter
the challenges list by programming language. Backend counterpart of parent
issue #990 *[CHALLENGE] Filter challenges by language*.

## Changes

- Extend `ChallengeRepository` port with `findByLanguage(ChallengeLanguage)`.
- Implement the filter in `InMemoryChallengeRepository` (returns an immutable list).
- Add optional `language` query param to `ChallengeController.findAll()`.
  Spring binds the enum and returns 400 on invalid values automatically.
- Add unit tests for the repository (2) and controller (2).
- Drive-by SonarLint cleanups in adjacent code (see commit message for the full list).

## Verification

- `./gradlew :challenge-service:test` from `backend/`: BUILD SUCCESSFUL, 51 tests pass (4 new).
- Manual check with the `full` Docker profile running:
  - `GET /api/challenge` returns the full list.
  - `GET /api/challenge?language=JAVA` returns only Java challenges.
  - `GET /api/challenge?language=COBOL` returns 400.

## Out of scope

- Aligning the catalog context with an `application/` use case layer.
- Filtering by multiple criteria, pagination, sorting.

Closes #1010