### PR TITLE
feat(auth): prevent guest users from accessing tickets route

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { AppLayoutComponent } from './layout/components/app-layout.component';
 import { NotFoundPage } from './shared/pages/not-found-page';
+import {authGuard} from './core/guards/auth-guard';
 
 export const appRoutes: Routes = [
   {
@@ -39,6 +40,7 @@ export const appRoutes: Routes = [
       },
       {
         path: 'tickets',
+        canActivate: [authGuard],
         loadChildren: () =>
           import('./features/tickets/tickets.routes').then(m => m.TICKETS_ROUTES),
       },      {


### PR DESCRIPTION
Currently, if a guest user (unauthenticated) navigated to the /tickets route, the frontend allowed the visual component to load, even though the backend denied the data request (returning a 401 error and failing due to CORS).

The security guard has been implemented in the route configuration to intercept this behavior and properly redirect to the login screen.

- Add authGuard to the tickets path in appRoutes configuration.
- Intercept unauthenticated users and redirect them to the login screen.
- Resolves #1022