### PR TITLE
[TICKET] provide sample users for the demo

### DIFF
--- a/backend/account-service/build.gradle
+++ b/backend/account-service/build.gradle
@@ -16,6 +16,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test' 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly('org.projectlombok:lombok')
+	annotationProcessor('org.projectlombok:lombok')
+
+	testCompileOnly('org.projectlombok:lombok')
+	testAnnotationProcessor('org.projectlombok:lombok')
 }
 
 tasks.named('test') {

--- a/backend/account-service/build.gradle
+++ b/backend/account-service/build.gradle
@@ -16,12 +16,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test' 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	compileOnly('org.projectlombok:lombok')
-	annotationProcessor('org.projectlombok:lombok')
-
-	testCompileOnly('org.projectlombok:lombok')
-	testAnnotationProcessor('org.projectlombok:lombok')
 }
 
 tasks.named('test') {

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/seed/UsersSeedLoader.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/seed/UsersSeedLoader.java
@@ -3,16 +3,18 @@ package com.ita.challenges.account.infrastructure.seed;
 import com.ita.challenges.account.domain.model.Role;
 import com.ita.challenges.account.domain.model.User;
 import com.ita.challenges.account.domain.port.out.UserRepository;
-import lombok.AllArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
-@AllArgsConstructor
 public class UsersSeedLoader implements CommandLineRunner {
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    public UsersSeedLoader(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public void run(String... args) {

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/seed/UsersSeedLoader.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/seed/UsersSeedLoader.java
@@ -1,0 +1,30 @@
+package com.ita.challenges.account.infrastructure.seed;
+
+import com.ita.challenges.account.domain.model.Role;
+import com.ita.challenges.account.domain.model.User;
+import com.ita.challenges.account.domain.port.out.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@AllArgsConstructor
+public class UsersSeedLoader implements CommandLineRunner {
+    private UserRepository userRepository;
+
+    @Override
+    public void run(String... args) {
+        List<User> initialUsers = List.of(
+                new User("John Peter", Role.MENTOR),
+                new User("Jane Doe", Role.MENTOR),
+                new User("Alice Smith", Role.MENTOR),
+                new User("Bob Johnson", Role.GUEST),
+                new User("Jane Lee", Role.GUEST),
+                new User("Charlie Brown", Role.STUDENT),
+                new User("Emily Davis", Role.STUDENT)
+        );
+        initialUsers.forEach(userRepository::save);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a data seeder to automatically populate the system with test data upon application startup. It ensures the environment is ready for testing and demonstrations without requiring manual setup.

### Technical Changes
* Implemented startup logic to initialize sample `User` records.
* Seeded records are stored in the `InMemoryUserRepository`.
* All generated users are explicitly assigned the `Role.MENTOR` value.
* Add Lombok dependency for improved code generation
