### PR TITLE
[TICKET] get the list of mentors

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/UserRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/port/out/UserRepository.java
@@ -2,10 +2,13 @@ package com.ita.challenges.account.domain.port.out;
 
 import com.ita.challenges.account.domain.model.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
     Optional<User> findByUsername(String username);
 
     User save(User user);
+
+    List<User> findAllMentors();
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserController.java
@@ -1,6 +1,7 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in;
 
 import com.ita.challenges.account.domain.port.out.UserRepository;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserResponse;
 import com.ita.challenges.account.infrastructure.adapter.web.in.dto.UserRoleResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 
 @RestController
@@ -26,5 +29,12 @@ public class UserController {
         return userRepository.findByUsername(username)
                 .map(user -> ResponseEntity.ok(new UserRoleResponse(user.userRole())))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+    }
+
+    @GetMapping("/mentors")
+    public ResponseEntity<List<UserResponse>> getAllMentors() {
+        return ResponseEntity.ok(userRepository.findAllMentors().stream()
+                .map(user -> new UserResponse(user.userName(), user.userRole()))
+                .toList());
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepository.java
@@ -1,9 +1,11 @@
 package com.ita.challenges.account.infrastructure.adapter.web.out.persistence;
 
+import com.ita.challenges.account.domain.model.Role;
 import com.ita.challenges.account.domain.model.User;
 import com.ita.challenges.account.domain.port.out.UserRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -21,5 +23,12 @@ public class InMemoryUserRepository implements UserRepository {
     public User save(User user) {
         storage.put(user.userName(), user);
         return user;
+    }
+
+    @Override
+    public List<User> findAllMentors() {
+        return storage.values().stream()
+                .filter(user -> user.userRole() == Role.MENTOR)
+                .toList();
     }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/UserControllerTest.java
@@ -10,12 +10,14 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.Mockito.when;
@@ -72,6 +74,25 @@ class UserControllerTest {
     void shouldReturn401WhenNotAuthenticated() throws Exception {
         mockMvc.perform(get("/api/account/users/me"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAllMentors_ShouldReturnListOfUserResponseAndStatusOk() throws Exception {
+        User mentor1 = new User("juan123", Role.MENTOR);
+        User mentor2 = new User("maria456", Role.MENTOR);
+
+        when(userRepository.findAllMentors())
+                .thenReturn(List.of(mentor1, mentor2));
+
+
+        mockMvc.perform(get("/api/account/users/mentors")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].username").value("juan123"))
+                .andExpect(jsonPath("$[0].role").value("MENTOR"))
+                .andExpect(jsonPath("$[1].username").value("maria456"))
+                .andExpect(jsonPath("$[1].role").value("MENTOR"));
     }
 
     @TestConfiguration

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryUserRepositoryTest.java
@@ -50,4 +50,16 @@ class InMemoryUserRepositoryTest {
         assertTrue(found.isPresent());
         assertEquals(Role.GUEST, found.get().userRole());
     }
+
+    @Test
+    void findAllMentors_shouldReturnOnlyMentors() {
+        repository.save(new User("mentor1", Role.MENTOR));
+        repository.save(new User("guest1", Role.GUEST));
+        repository.save(new User("mentor2", Role.MENTOR));
+
+        var mentors = repository.findAllMentors();
+
+        assertThat(mentors).hasSize(2);
+        assertThat(mentors).allMatch(user -> user.userRole() == Role.MENTOR);
+    }
 }


### PR DESCRIPTION
### Description
This PR exposes a new API endpoint to retrieve the list of available mentors. It allows the system to look up and display mentors for future assignments.

### Technical Changes
* Created a new `GET "/mentors"` route in the controller layer.
* Implemented filtering logic to query the `InMemoryUserRepository` and return **only** users with the `Role.MENTOR` value.
* Used the `userName` as the unique identifier in the response payload to align with current infrastructure logic.