### PR TITLE
[TICKET] add mentor field to ticket

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/domain/model/Ticket.java
@@ -7,6 +7,7 @@ public class Ticket {
 
     private final String id;
     private final String userId;
+    private final String mentorAssignedId;
     private final String title;
     private final String description;
     private final TicketStatus status;
@@ -14,10 +15,11 @@ public class Ticket {
     private final Instant createdAt;
     private final Instant updatedAt;
 
-    private Ticket(String id, String userId, String title, String description,
-                   TicketStatus status, String comment, Instant createdAt, Instant updatedAt){
+    private Ticket(String id, String userId, String mentorAssignedId, String title, String description,
+                   TicketStatus status, String comment, Instant createdAt, Instant updatedAt) {
         this.id = id;
         this.userId = userId;
+        this.mentorAssignedId = mentorAssignedId;
         this.title = title;
         this.description = description;
         this.status = status;
@@ -31,6 +33,7 @@ public class Ticket {
         return new Ticket(
                 UUID.randomUUID().toString(),
                 userId,
+                null,
                 title,
                 description,
                 TicketStatus.OPEN,
@@ -41,10 +44,11 @@ public class Ticket {
     }
 
     @Deprecated
-    public static Ticket restore(String id, String userId, String title, String description) {
+    public static Ticket restore(String id, String userId, String mentorAssignedId, String title, String description) {
         return new Ticket(
                 id,
                 userId,
+                mentorAssignedId,
                 title,
                 description,
                 TicketStatus.OPEN,
@@ -54,22 +58,38 @@ public class Ticket {
         );
     }
 
-    public static Ticket restore(String id, String userId, String title, String description,
-            TicketStatus status, String comment, Instant createdAt, Instant updatedAt) {
-        return new Ticket(id, userId, title, description, status, comment, createdAt, updatedAt);
+    public static Ticket restore(String id, String userId, String mentorAssignedId, String title, String description,
+                                 TicketStatus status, String comment, Instant createdAt, Instant updatedAt) {
+        return new Ticket(id, userId, mentorAssignedId, title, description, status, comment, createdAt, updatedAt);
     }
     public Ticket withUpdates(TicketStatus status, String comment) {
-    return new Ticket(
-            this.id,
-            this.userId,
-            this.title,
-            this.description,
-            status != null ? status : this.status,
-            comment != null ? comment : this.comment,
-            this.createdAt,
-            Instant.now()
-    );
+        return new Ticket(
+                this.id,
+                this.userId,
+                this.mentorAssignedId,
+                this.title,
+                this.description,
+                status != null ? status : this.status,
+                comment != null ? comment : this.comment,
+                this.createdAt,
+                Instant.now()
+        );
     }
+
+    public Ticket assignMentor(String mentorId) {
+        return new Ticket(
+                this.id,
+                this.userId,
+                mentorId,
+                this.title,
+                this.description,
+                this.status,
+                this.comment,
+                this.createdAt,
+                Instant.now()
+        );
+    }
+
     public String getId() {
         return id;
     }
@@ -96,5 +116,9 @@ public class Ticket {
     }
     public Instant getUpdatedAt() {
         return updatedAt;
+    }
+
+    public String getMentorAssignedId() {
+        return mentorAssignedId;
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -52,6 +52,7 @@ public class TicketController {
                 .body(new TicketResponse(
                         savedTicket.getId(),
                         savedTicket.getUserId(),
+                        savedTicket.getMentorAssignedId(),
                         savedTicket.getTitle(),
                         savedTicket.getDescription()
                 ));
@@ -70,6 +71,7 @@ public class TicketController {
                 .map(ticket -> new TicketPatchResponse(
                         ticket.getId(),
                         ticket.getUserId(),
+                        ticket.getMentorAssignedId(),
                         ticket.getTitle(),
                         ticket.getDescription(),
                         ticket.getStatus(),
@@ -99,6 +101,7 @@ public class TicketController {
                     Ticket updatedTicket = Ticket.restore(
                             id,
                             existingTicket.getUserId(),
+                            existingTicket.getMentorAssignedId(),
                             ticketRequest.title(),
                             ticketRequest.description()
                     );
@@ -106,6 +109,7 @@ public class TicketController {
                     return ResponseEntity.ok(new TicketResponse(
                             savedTicket.getId(),
                             savedTicket.getUserId(),
+                            savedTicket.getMentorAssignedId(),
                             savedTicket.getTitle(),
                             savedTicket.getDescription()
                     ));
@@ -126,6 +130,7 @@ public class TicketController {
                     return ResponseEntity.ok(new TicketResponse(
                             ticket.getId(),
                             ticket.getUserId(),
+                            ticket.getMentorAssignedId(),
                             ticket.getTitle(),
                             ticket.getDescription()
                     ));
@@ -163,6 +168,7 @@ public class TicketController {
                     return ResponseEntity.ok(new TicketPatchResponse(
                             savedTicket.getId(),
                             savedTicket.getUserId(),
+                            savedTicket.getMentorAssignedId(),
                             savedTicket.getTitle(),
                             savedTicket.getDescription(),
                             savedTicket.getStatus(),

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketPatchResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketPatchResponse.java
@@ -2,6 +2,6 @@ package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
 
 import com.ita.challenges.account.domain.model.TicketStatus;
 
-public record TicketPatchResponse(String id, String userId, String title, String description, TicketStatus ticketStatus, String ticketComment
+public record TicketPatchResponse(String id, String userId, String mentorAssignedId, String title, String description, TicketStatus ticketStatus, String ticketComment
                                   ) {
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketResponse.java
@@ -1,3 +1,3 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
 
-public record TicketResponse(String id, String userId, String mentorAssignId, String title, String description) {}
+public record TicketResponse(String id, String userId, String mentorAssignedId, String title, String description) {}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketResponse.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketResponse.java
@@ -1,3 +1,3 @@
 package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
 
-public record TicketResponse(String id, String userId, String title, String description) {}
+public record TicketResponse(String id, String userId, String mentorAssignId, String title, String description) {}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/application/service/CreateTicketServiceTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/application/service/CreateTicketServiceTest.java
@@ -27,7 +27,7 @@ class CreateTicketServiceTest {
         String title = "Fix login issue";
         String description = "The login button is not responding on mobile devices.";
 
-        Ticket mockSavedTicket = Ticket.restore("ticket-999", userId, title, description);
+        Ticket mockSavedTicket = Ticket.restore("ticket-999", userId, null, title, description);
 
         when(ticketRepository.save(any(Ticket.class))).thenReturn(mockSavedTicket);
 

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -51,7 +51,7 @@ class TicketControllerTest {
     @Test
     void should_create_ticket_and_return_201_created() throws Exception {
         TicketRequest request = new TicketRequest("Test Title", "Test description");
-        Ticket mockTicket = Ticket.restore("ticket-123", "tester", request.title(), request.description());
+        Ticket mockTicket = Ticket.restore("ticket-123", "tester", null, request.title(), request.description());
 
         when(ticketRepository.save(any(Ticket.class))).thenReturn(mockTicket);
 
@@ -63,6 +63,7 @@ class TicketControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("ticket-123"))
                 .andExpect(jsonPath("$.userId").value("tester"))
+                .andExpect(jsonPath("$.mentorAssignedId").doesNotExist())
                 .andExpect(jsonPath("$.title").value("Test Title"))
                 .andExpect(jsonPath("$.description").value("Test description"));
         verify(ticketRepository).save(any(Ticket.class));
@@ -100,7 +101,7 @@ class TicketControllerTest {
         String ticketId = "ticket-123";
         String currentUserId = "user-1";
 
-        Ticket existingTicket = Ticket.restore(ticketId, currentUserId, "Old Title", "Old Desc");
+        Ticket existingTicket = Ticket.restore(ticketId, currentUserId, null, "Old Title", "Old Desc");
         TicketRequest updateRequest = new TicketRequest("New Title", "New Desc");
 
         when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
@@ -113,6 +114,7 @@ class TicketControllerTest {
                         .content(objectMapper.writeValueAsString(updateRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(ticketId))
+                .andExpect(jsonPath("$.mentorAssignedId").doesNotExist())
                 .andExpect(jsonPath("$.title").value("New Title"))
                 .andExpect(jsonPath("$.userId").value(currentUserId));
     }
@@ -138,7 +140,7 @@ class TicketControllerTest {
         String ownerId = "user-1";
         String hackerId = "hacker-99";
 
-        Ticket existingTicket = Ticket.restore(ticketId, ownerId, "Title", "Desc");
+        Ticket existingTicket = Ticket.restore(ticketId, ownerId, null, "Title", "Desc");
         TicketRequest updateRequest = new TicketRequest("New Title", "New Desc");
 
         when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
@@ -157,7 +159,7 @@ class TicketControllerTest {
         String ticketId = "ticket-123";
         String ownerId = "user-11";
 
-        Ticket existingTicket = Ticket.restore(ticketId, ownerId, "Title for test", "Description for tests");
+        Ticket existingTicket = Ticket.restore(ticketId, ownerId, null,"Title for test", "Description for tests");
 
         when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
 
@@ -174,7 +176,7 @@ class TicketControllerTest {
         String ticketId = "ticket-123";
         String currentUserId = "user-1";
 
-        Ticket existingTicket = Ticket.restore(ticketId, currentUserId, "Old Title", "Old Desc");
+        Ticket existingTicket = Ticket.restore(ticketId, currentUserId, null, "Old Title", "Old Desc");
         TicketPatchRequest patchRequest = new TicketPatchRequest(TicketStatus.IN_PROGRESS, "Working on it");
 
         User mockUser = new User(currentUserId, Role.MENTOR);
@@ -192,6 +194,7 @@ class TicketControllerTest {
                         .content(objectMapper.writeValueAsString(patchRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(ticketId))
+                .andExpect(jsonPath("$.mentorAssignedId").doesNotExist())
                 .andExpect(jsonPath("$.title").value("Old Title"))
                 .andExpect(jsonPath("$.description").value("Old Desc"))
                 .andExpect(jsonPath("$.ticketStatus").value("IN_PROGRESS"))
@@ -202,7 +205,7 @@ class TicketControllerTest {
     @Test
     void should_return_200_with_ticket_list_when_user_is_authenticated() throws Exception {
         String userId = "user-42";
-        Ticket ticket = Ticket.restore("ticket-999", userId, "Payment error", "Card declined");
+        Ticket ticket = Ticket.restore("ticket-999", userId, null,  "Payment error", "Card declined");
 
         when(ticketRepository.findAllByUserId(userId)).thenReturn(List.of(ticket));
 
@@ -211,6 +214,7 @@ class TicketControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value("ticket-999"))
                 .andExpect(jsonPath("$[0].userId").value(userId))
+                .andExpect(jsonPath("$[0].mentorAssignedId").doesNotExist())
                 .andExpect(jsonPath("$[0].title").value("Payment error"))
                 .andExpect(jsonPath("$[0].description").value("Card declined"));
     }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/out/persistence/InMemoryTicketRepositoryTest.java
@@ -40,13 +40,14 @@ class InMemoryTicketRepositoryTest {
         Ticket original = Ticket.create("user-1", "Old Title", "Old Desc");
         repository.save(original);
 
-        Ticket updated = Ticket.restore(original.getId(), "user-1", "New Title", "New Desc");
+        Ticket updated = Ticket.restore(original.getId(),  "user-1", "No Assigned", "New Title", "New Desc");
         repository.updateTicket(updated);
 
         Optional<Ticket> result = repository.findById(original.getId());
         assertTrue(result.isPresent());
         assertEquals("New Title", result.get().getTitle());
         assertEquals("New Desc", result.get().getDescription());
+        assertEquals("No Assigned", result.get().getMentorAssignedId());
     }
 
     @Test
@@ -59,6 +60,7 @@ class InMemoryTicketRepositoryTest {
         assertTrue(found.isPresent(), "Ticket existing");
         assertEquals(ticket.getId(), found.get().getId());
         assertEquals("user-456", found.get().getUserId());
+        assertEquals("No Assigned", found.get().getMentorAssignedId());
     }
 
     @Test
@@ -75,7 +77,7 @@ class InMemoryTicketRepositoryTest {
         String title = "Restored Title";
         String desc = "Restored Desc";
 
-        Ticket restored = Ticket.restore(id, userId, title, desc);
+        Ticket restored = Ticket.restore(id, userId, "No Assigned", title, desc);
 
         assertNotNull(restored);
         assertEquals(id, restored.getId());


### PR DESCRIPTION
### Description
This PR updates the core domain model to support mentor assignment. It enables the ticket structure to safely store and update the reference to the assigned mentor.

### Technical Changes
* Added an optional `assignedMentorId` (String) field to the `Ticket` aggregate class.
* Updated the `Ticket` constructor, `.create()`, and `.restore()` factory methods to support this new property.
* Defaulted `assignedMentorId` to `null` for all new tickets.
* Ensured data backward compatibility within `.restore()` methods to protect existing tests.
* Added a clean domain method to update/transition the ticket state with the new mentor ID immutably.