### PR TITLE
[TICKET] assign a mentor to a ticket

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -176,7 +176,7 @@ public class TicketController {
     }
 
     @PatchMapping("/{id}/assign")
-    public ResponseEntity<?> assignMentor(@PathVariable String id,
+    public ResponseEntity<TicketPatchResponse> assignMentor(@PathVariable String id,
                                           @RequestBody TicketAssignRequest assignRequest,
                                           @AuthenticationPrincipal OAuth2User user) {
 
@@ -186,27 +186,28 @@ public class TicketController {
 
         String login = user.getAttribute("login");
 
-        User appUser = userRepository.findByUsername(login)
+        userRepository.findByUsername(login)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "User not registered"));
 
-        if (assignRequest.mentorAssignedId() == null || assignRequest.mentorAssignedId().isBlank()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Mentor ID cannot be empty");
+        if (assignRequest.mentorAssignedId() != null && !assignRequest.mentorAssignedId().isBlank()) {
+            userRepository.findByUsername(assignRequest.mentorAssignedId())
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "The assigned mentor does not exist"));
         }
 
-        return ticketRepository.findById(id)
-                .map(existingTicket -> {
-                    Ticket updatedTicket = existingTicket.assignMentor(assignRequest.mentorAssignedId());
-                    Ticket savedTicket = ticketRepository.updateTicket(updatedTicket);
+        Ticket existingTicket = ticketRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
 
-                    return ResponseEntity.ok(new TicketPatchResponse(
-                            savedTicket.getId(),
-                            savedTicket.getUserId(),
-                            savedTicket.mentorAssignedId(),
-                            savedTicket.getTitle(),
-                            savedTicket.getDescription(),
-                            savedTicket.getStatus()));
-                })
-                .orElse(ResponseEntity.notFound().build());
+        Ticket updatedTicket = existingTicket.assignMentor(assignRequest.mentorAssignedId());
+        Ticket savedTicket = ticketRepository.updateTicket(updatedTicket);
+
+        return ResponseEntity.ok(new TicketPatchResponse(
+                savedTicket.getId(),
+                savedTicket.getUserId(),
+                savedTicket.getMentorAssignedId(),
+                savedTicket.getTitle(),
+                savedTicket.getDescription(),
+                savedTicket.getStatus(),
+                savedTicket.getComment()
+        ));
     }
-
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketController.java
@@ -5,10 +5,7 @@ import com.ita.challenges.account.domain.model.Ticket;
 import com.ita.challenges.account.domain.model.User;
 import com.ita.challenges.account.domain.port.out.TicketRepository;
 import com.ita.challenges.account.domain.port.out.UserRepository;
-import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketPatchRequest;
-import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketPatchResponse;
-import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketRequest;
-import com.ita.challenges.account.infrastructure.adapter.web.in.dto.TicketResponse;
+import com.ita.challenges.account.infrastructure.adapter.web.in.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -174,6 +171,40 @@ public class TicketController {
                             savedTicket.getStatus(),
                             savedTicket.getComment()
                     ));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PatchMapping("/{id}/assign")
+    public ResponseEntity<?> assignMentor(@PathVariable String id,
+                                          @RequestBody TicketAssignRequest assignRequest,
+                                          @AuthenticationPrincipal OAuth2User user) {
+
+        if (user == null || user.getAttribute("login") == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String login = user.getAttribute("login");
+
+        User appUser = userRepository.findByUsername(login)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "User not registered"));
+
+        if (assignRequest.mentorAssignedId() == null || assignRequest.mentorAssignedId().isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Mentor ID cannot be empty");
+        }
+
+        return ticketRepository.findById(id)
+                .map(existingTicket -> {
+                    Ticket updatedTicket = existingTicket.assignMentor(assignRequest.mentorAssignedId());
+                    Ticket savedTicket = ticketRepository.updateTicket(updatedTicket);
+
+                    return ResponseEntity.ok(new TicketPatchResponse(
+                            savedTicket.getId(),
+                            savedTicket.getUserId(),
+                            savedTicket.mentorAssignedId(),
+                            savedTicket.getTitle(),
+                            savedTicket.getDescription(),
+                            savedTicket.getStatus()));
                 })
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketAssignRequest.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/adapter/web/in/dto/TicketAssignRequest.java
@@ -1,0 +1,5 @@
+package com.ita.challenges.account.infrastructure.adapter.web.in.dto;
+
+public record TicketAssignRequest (String ticketId, String mentorAssignedId) {
+
+}

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -218,4 +218,49 @@ class TicketControllerTest {
                 .andExpect(jsonPath("$[0].title").value("Payment error"))
                 .andExpect(jsonPath("$[0].description").value("Card declined"));
     }
+
+    @Test
+    void should_assign_mentor_successfully_and_return_200() throws Exception {
+        String ticketId = "ticket-123";
+        String adminLogin = "admin-user";
+        String targetMentorId = "mentor-brian";
+
+        Ticket existingTicket = Ticket.restore(
+                ticketId, "student-1", null, "Title", "Desc"
+        );
+
+        User mockAdmin = new User(adminLogin, Role.MENTOR);
+
+        when(userRepository.findByUsername(adminLogin)).thenReturn(Optional.of(mockAdmin));
+        when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
+        when(ticketRepository.updateTicket(any(Ticket.class))).thenAnswer(i -> i.getArguments()[0]);
+
+        mockMvc.perform(patch("/api/account/tickets/{id}/assign", ticketId)
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", adminLogin)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"mentorAssignedId\":\"" + targetMentorId + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(ticketId))
+                .andExpect(jsonPath("$.mentorAssignedId").value(targetMentorId))
+                .andExpect(jsonPath("$.title").value("Title"))
+                .andExpect(jsonPath("$.ticketStatus").value("OPEN"));
+    }
+
+    @Test
+    void should_return_400_when_mentor_id_is_blank() throws Exception {
+        String ticketId = "ticket-123";
+        String adminLogin = "admin-user";
+        User mockAdmin = new User(adminLogin, Role.MENTOR);
+
+        when(userRepository.findByUsername(adminLogin)).thenReturn(Optional.of(mockAdmin));
+
+        mockMvc.perform(patch("/api/account/tickets/{id}/assign", ticketId)
+                        .with(csrf())
+                        .with(oauth2Login().attributes(attrs -> attrs.put("login", adminLogin)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"mentorAssignedId\":\"   \"}")) // Espacios en blanco
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Mentor ID cannot be empty"));
+    }
 }

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/adapter/web/in/TicketControllerTest.java
@@ -230,8 +230,10 @@ class TicketControllerTest {
         );
 
         User mockAdmin = new User(adminLogin, Role.MENTOR);
+        User mockMentor = new User(targetMentorId, Role.MENTOR);
 
         when(userRepository.findByUsername(adminLogin)).thenReturn(Optional.of(mockAdmin));
+        when(userRepository.findByUsername(targetMentorId)).thenReturn(Optional.of(mockMentor));
         when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(existingTicket));
         when(ticketRepository.updateTicket(any(Ticket.class))).thenAnswer(i -> i.getArguments()[0]);
 
@@ -245,22 +247,5 @@ class TicketControllerTest {
                 .andExpect(jsonPath("$.mentorAssignedId").value(targetMentorId))
                 .andExpect(jsonPath("$.title").value("Title"))
                 .andExpect(jsonPath("$.ticketStatus").value("OPEN"));
-    }
-
-    @Test
-    void should_return_400_when_mentor_id_is_blank() throws Exception {
-        String ticketId = "ticket-123";
-        String adminLogin = "admin-user";
-        User mockAdmin = new User(adminLogin, Role.MENTOR);
-
-        when(userRepository.findByUsername(adminLogin)).thenReturn(Optional.of(mockAdmin));
-
-        mockMvc.perform(patch("/api/account/tickets/{id}/assign", ticketId)
-                        .with(csrf())
-                        .with(oauth2Login().attributes(attrs -> attrs.put("login", adminLogin)))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"mentorAssignedId\":\"   \"}")) // Espacios en blanco
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string("Mentor ID cannot be empty"));
     }
 }


### PR DESCRIPTION
### Description
This PR implements the API endpoint that allows administrators or mentors to officially assign a mentor to an unassigned ticket. It handles payload mapping, authorization checks, and repository updates.

### Technical Changes
* Extended the `TicketController` with a `PATCH /api/account/tickets/{id}/assign`) endpoint.
* Configured the endpoint to accept a payload containing the mentor's identifier (`userName`).
* Integrated the controller action with the repository to persist the ticket's updated state with its new assigned mentor.

⚠️ ALERT  
This PR depends on #1041 because this endpoint requires the domain to be prepared first.