### PR TITLE
Bugfix/tickets routing

### DIFF
--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -27,11 +28,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        processOAuth2User(oAuth2User);
-
-        List<SimpleGrantedAuthority> authorities = Collections.singletonList(
-                new SimpleGrantedAuthority("ROLE_STUDENT")
-        );
+        List<SimpleGrantedAuthority> authorities = processOAuth2User(oAuth2User);
 
         return new DefaultOAuth2User(
                 authorities,
@@ -40,12 +37,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         );
     }
 
-    public void processOAuth2User(OAuth2User oAuth2User) {
+    public List<SimpleGrantedAuthority> processOAuth2User(OAuth2User oAuth2User) {
         String login = oAuth2User.getAttribute("login");
 
-        if (login != null && userRepository.findByUsername(login).isEmpty()) {
-            User newUser = new User(login, Role.STUDENT);
-            userRepository.save(newUser);
+        if (login == null) {
+            throw new OAuth2AuthenticationException("Login not found in GitHub");
         }
+
+        Optional<User> existingUser = userRepository.findByUsername(login);
+        User user;
+
+        if (existingUser.isEmpty()) {
+            user = new User(login, Role.STUDENT);
+            userRepository.save(user);
+
+        } else {
+            user = existingUser.get();
+        }
+
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + user.userRole().name())
+        );
     }
 }

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
@@ -3,11 +3,16 @@ package com.ita.challenges.account.infrastructure.config;
 import com.ita.challenges.account.domain.model.Role;
 import com.ita.challenges.account.domain.model.User;
 import com.ita.challenges.account.domain.port.out.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -21,9 +26,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
+
         processOAuth2User(oAuth2User);
 
-        return oAuth2User;
+        List<SimpleGrantedAuthority> authorities = Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_STUDENT")
+        );
+
+        return new DefaultOAuth2User(
+                authorities,
+                oAuth2User.getAttributes(),
+                "login"
+        );
     }
 
     public void processOAuth2User(OAuth2User oAuth2User) {

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserService.java
@@ -1,0 +1,37 @@
+package com.ita.challenges.account.infrastructure.config;
+
+import com.ita.challenges.account.domain.model.Role;
+import com.ita.challenges.account.domain.model.User;
+import com.ita.challenges.account.domain.port.out.UserRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public CustomOAuth2UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        processOAuth2User(oAuth2User);
+
+        return oAuth2User;
+    }
+
+    public void processOAuth2User(OAuth2User oAuth2User) {
+        String login = oAuth2User.getAttribute("login");
+
+        if (login != null && userRepository.findByUsername(login).isEmpty()) {
+            User newUser = new User(login, Role.STUDENT);
+            userRepository.save(newUser);
+        }
+    }
+}

--- a/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
+++ b/backend/account-service/src/main/java/com/ita/challenges/account/infrastructure/config/SecurityConfig.java
@@ -4,11 +4,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
+
+    public SecurityConfig(OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService) {
+        this.customOAuth2UserService = customOAuth2UserService;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -27,6 +36,9 @@ public class SecurityConfig {
                         )
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/api/account/login/oauth2/code/**")
+                        )
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)
                         )
                         .defaultSuccessUrl("/challenges")
                 )

--- a/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserServiceTest.java
+++ b/backend/account-service/src/test/java/com/ita/challenges/account/infrastructure/config/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.ita.challenges.account.infrastructure.config;
+
+import com.ita.challenges.account.domain.model.Role;
+import com.ita.challenges.account.domain.model.User;
+import com.ita.challenges.account.domain.port.out.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OAuth2User oAuth2User;
+
+    @InjectMocks
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Test
+    @DisplayName("Should save a new user with STUDENT role if it does not exist in DB")
+    void shouldSaveNewUserWhenUserDoesNotExist() {
+        String mockUsername = "Spook242";
+
+        when(oAuth2User.getAttribute("login")).thenReturn(mockUsername);
+        when(userRepository.findByUsername(mockUsername)).thenReturn(Optional.empty());
+
+        customOAuth2UserService.processOAuth2User(oAuth2User);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+
+        verify(userRepository, times(1)).save(userCaptor.capture());
+
+        User savedUser = userCaptor.getValue();
+
+        assertThat(savedUser.userName()).isEqualTo(mockUsername);
+        assertThat(savedUser.userRole()).isEqualTo(Role.STUDENT);
+    }
+
+    @Test
+    @DisplayName("Should not save anything if the user already exists in DB")
+    void shouldNotSaveWhenUserAlreadyExists() {
+        String mockUsername = "ExistingUser";
+
+        when(oAuth2User.getAttribute("login")).thenReturn(mockUsername);
+
+        User existingUser = new User(mockUsername, Role.MENTOR);
+
+        when(userRepository.findByUsername(mockUsername)).thenReturn(Optional.of(existingUser));
+
+        customOAuth2UserService.processOAuth2User(oAuth2User);
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+}

--- a/frontend/src/app/layout/components/header/header.ts
+++ b/frontend/src/app/layout/components/header/header.ts
@@ -21,7 +21,6 @@ export class Header implements OnInit {
     this.authService.fetchUser().subscribe({
       next: (user) => {
         this.authService.setUser(user);
-        this.router.navigate(['/challenges']);
       },
     });
   }


### PR DESCRIPTION
I am closing this PR as it accidentally includes unrelated changes due to branch merging issues. I will open a new, clean PR shortly with only the intended changes


Problem Description
When accessing a specific route directly via the browser's address bar (http://localhost:8080/tickets) or when reloading the page with F5, the application automatically redirected the user to the /challenges page, preventing direct access to /tickets.

The responsible element was the global Header component. In its ngOnInit, when retrieving user data after a reload (fetchUser()), it executed a router.navigate(['/challenges']) unconditionally.

Solution
The static redirect instruction inside the fetchUser() subscription in the Header has been removed. Now, the authentication state is retrieved without interfering with the URL requested by the user.

Modified Files
frontend/src/app/layout/components/header/header.ts (Removed forced redirection).

Closes #1026 