### PR TITLE
fix(routing): remove forced redirect from header component

### DIFF
--- a/frontend/src/app/layout/components/header/header.ts
+++ b/frontend/src/app/layout/components/header/header.ts
@@ -21,7 +21,6 @@ export class Header implements OnInit {
     this.authService.fetchUser().subscribe({
       next: (user) => {
         this.authService.setUser(user);
-        this.router.navigate(['/challenges']);
       },
     });
   }


### PR DESCRIPTION
Problem Description
When accessing a specific route directly via the browser's address bar (http://localhost:8080/tickets) or when reloading the page with F5, the application automatically redirected the user to the /challenges page, preventing direct access to /tickets.

The responsible element was the global Header component. In its ngOnInit, when retrieving user data after a reload (fetchUser()), it executed a router.navigate(['/challenges']) unconditionally.

Solution
The static redirect instruction inside the fetchUser() subscription in the Header has been removed. Now, the authentication state is retrieved without interfering with the URL requested by the user.

Modified Files
frontend/src/app/layout/components/header/header.ts (Removed forced redirection).

Closes #1026 