### PR TITLE
feat(filter-chip): add reusable filter chip component 1/2 #1009

### DIFF
--- a/frontend/src/app/shared/components/filter-chip/filter-chip.css
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.css
@@ -1,0 +1,34 @@
+.filter-chip {
+  appearance: none;
+  cursor: pointer;
+  padding: 0.6rem 1.8rem;
+
+  font-family: var(--font-family);
+  font-size: var(--font-size-normal);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-body);
+  color: var(--color-black-2);
+
+  background-color: var(--color-white);
+  border: 1.5px solid var(--color-gray-4);
+  border-radius: 999px;
+
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.filter-chip--active {
+  background-color: var(--color-black-2);
+  border-color: var(--color-black-2);
+  color: var(--color-white);
+  font-weight: var(--font-weight-bold);
+}
+
+.filter-chip:not(.filter-chip--active):hover {
+  border-color: var(--color-gray-3);
+  background-color: var(--color-gray-4);
+}
+
+.filter-chip:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/frontend/src/app/shared/components/filter-chip/filter-chip.css
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.css
@@ -2,6 +2,7 @@
   appearance: none;
   cursor: pointer;
   padding: 0.6rem 1.8rem;
+  margin: 0 0.5rem;
 
   font-family: var(--font-family);
   font-size: var(--font-size-normal);
@@ -20,7 +21,6 @@
   background-color: var(--color-black-2);
   border-color: var(--color-black-2);
   color: var(--color-white);
-  font-weight: var(--font-weight-bold);
 }
 
 .filter-chip:not(.filter-chip--active):hover {

--- a/frontend/src/app/shared/components/filter-chip/filter-chip.html
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.html
@@ -1,10 +1,4 @@
-<button
-  data-testid="filter-chip-button"
-  class="filter-chip"
-  [class.filter-chip--active]="active()"
-  [attr.aria-pressed]="active()"
-  (click)="clicked.emit()"
-  type="button"
+<button data-testid="filter-chip-button" class="filter-chip" [class.filter-chip--active]="active()" [attr.aria-pressed]="active()" (click)="clicked.emit()" type="button"
 >
   {{ label() }}
 </button>

--- a/frontend/src/app/shared/components/filter-chip/filter-chip.html
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.html
@@ -1,0 +1,10 @@
+<button
+  data-testid="filter-chip-button"
+  class="filter-chip"
+  [class.filter-chip--active]="active()"
+  [attr.aria-pressed]="active()"
+  (click)="clicked.emit()"
+  type="button"
+>
+  {{ label() }}
+</button>

--- a/frontend/src/app/shared/components/filter-chip/filter-chip.spec.ts
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FilterChipComponent } from './filter-chip';
+
+describe('FilterChipComponent', () => {
+  let fixture: ComponentFixture<FilterChipComponent>;
+
+  const getButton = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('[data-testid="filter-chip-button"]');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FilterChipComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilterChipComponent);
+  });
+
+  it('should render the label', () => {
+    fixture.componentRef.setInput('label', 'Java');
+    fixture.detectChanges();
+    expect(getButton().textContent?.trim()).toBe('Java');
+  });
+
+  it('should not have active class by default', () => {
+    fixture.componentRef.setInput('label', 'Java');
+    fixture.detectChanges();
+    expect(getButton().classList).not.toContain('filter-chip--active');
+  });
+
+  it('should apply active class when active is true', () => {
+    fixture.componentRef.setInput('label', 'Java');
+    fixture.componentRef.setInput('active', true);
+    fixture.detectChanges();
+    expect(getButton().classList).toContain('filter-chip--active');
+  });
+
+  it('should emit clicked when button is clicked', () => {
+    fixture.componentRef.setInput('label', 'Java');
+    fixture.detectChanges();
+
+    let emitted = false;
+    fixture.componentInstance.clicked.subscribe(() => (emitted = true));
+
+    getButton().click();
+    expect(emitted).toBe(true);
+  });
+});

--- a/frontend/src/app/shared/components/filter-chip/filter-chip.ts
+++ b/frontend/src/app/shared/components/filter-chip/filter-chip.ts
@@ -1,0 +1,14 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-filter-chip',
+  standalone: true,
+  templateUrl: './filter-chip.html',
+  styleUrl: './filter-chip.css',
+})
+export class FilterChipComponent {
+  label = input.required<string>();
+  active = input<boolean>(false);
+
+  clicked = output<void>();
+}


### PR DESCRIPTION
## Description
Adds a new reusable `FilterChipComponent` to `shared/components` that displays a toggleable pill-shaped button.

⚠️ This pull request precedes number #1054. Merge this one first before merging the other.

## Changes
- New standalone component with `label` (required) and `active` inputs, and a `clicked` output
- Visual states: default (white background, gray border) and active (dark background, white text)
- `data-testid` attribute for reliable test selection
- Unit tests covering label rendering, default state, active state and click emission

## Out of scope
Integration with parent components and filter logic will be handled in a separate PR.