### PR TITLE
adding new methods to Submission.java and creating SubmissionBuffer.java

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -45,4 +45,42 @@ public class Submission {
         return submission;
     }
 
+    public static Submission restore(SubmissionId id, ChallengeId challengeId, UserId userId,
+                                     SubmissionStatus status, String code,
+                                     Instant createdAt, Instant updatedAt) {
+        Submission submission = new Submission();
+        submission.id = id;
+        submission.challengeId = challengeId;
+        submission.userId = userId;
+        submission.status = status;
+        submission.code = code;
+        submission.createdAt = createdAt;
+        submission.updatedAt = updatedAt;
+        return submission;
+    }
+
+    public static Submission toSubmitted(Submission draft) {
+        Submission submission = new Submission();
+        submission.id = draft.id;
+        submission.challengeId = draft.challengeId;
+        submission.userId = draft.userId;
+        submission.code = draft.code;
+        submission.status = SubmissionStatus.SUBMITTED;
+        submission.createdAt = draft.createdAt;
+        submission.updatedAt = Instant.now();
+        return submission;
+    }
+
+    public static Submission toInProgress(Submission existing) {
+        Submission submission = new Submission();
+        submission.id = existing.id;
+        submission.challengeId = existing.challengeId;
+        submission.userId = existing.userId;
+        submission.code = existing.code;
+        submission.status = SubmissionStatus.IN_PROGRESS;
+        submission.createdAt = existing.createdAt;
+        submission.updatedAt = Instant.now();
+        return submission;
+    }
+
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/domain/Submission.java
@@ -71,6 +71,11 @@ public class Submission {
         return submission;
     }
 
+    public void updateCode(String newCode) {
+    this.code = newCode;
+    this.updatedAt = Instant.now();
+}
+    
     public static Submission toInProgress(Submission existing) {
         Submission submission = new Submission();
         submission.id = existing.id;

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBuffer.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBuffer.java
@@ -26,10 +26,6 @@ public final class SubmissionBuffer {
         return Optional.ofNullable(BUFFER.get(userId));
     }
 
-    public static boolean existsByUserId(UserId userId) {
-        return BUFFER.containsKey(userId);
-    }
-
     public static void removeByUserId(UserId userId) {
         BUFFER.remove(userId);
     }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBuffer.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBuffer.java
@@ -1,0 +1,40 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer;
+
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.Submission;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionStatus;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class SubmissionBuffer {
+
+    private static final Map<UserId, Submission> BUFFER = new ConcurrentHashMap<>();
+    private SubmissionBuffer() {
+        throw new UnsupportedOperationException("This is a utility/buffer class and should not be instantiated");
+    }
+
+    public static void save(UserId userId, Submission submission) {
+        if (submission.getStatus() != SubmissionStatus.IN_PROGRESS) {
+            throw new IllegalArgumentException("Only IN_PROGRESS submissions can be stored in buffer");
+        }
+        BUFFER.put(userId, submission);
+    }
+
+    public static Optional<Submission> findLastByUserId(UserId userId) {
+        return Optional.ofNullable(BUFFER.get(userId));
+    }
+
+    public static boolean existsByUserId(UserId userId) {
+        return BUFFER.containsKey(userId);
+    }
+
+    public static void removeByUserId(UserId userId) {
+        BUFFER.remove(userId);
+    }
+
+    public static void clear() {
+        BUFFER.clear();
+    }
+}

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBufferTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBufferTest.java
@@ -4,32 +4,17 @@ import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId
 import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SubmissionBufferTest {
-    private final UserId userId = new UserId(UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
-    private Submission submission;
-
-    @BeforeEach
-    void setUp() {
-        SubmissionBuffer.clear();
-        submission = Submission.createInProgress(SubmissionId.generate(),
-                new ChallengeId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
-                userId, "code");
-    }
-
     @Test
-    void should_save_and_find() {
+    void should_save_and_find_and_remove() {
+        var userId = new UserId(UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
+        var submission = Submission.createInProgress(SubmissionId.generate(), new ChallengeId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")), userId, "code");
         SubmissionBuffer.save(userId, submission);
         assertThat(SubmissionBuffer.findLastByUserId(userId)).isPresent();
-    }
-
-    @Test
-    void should_remove() {
-        SubmissionBuffer.save(userId, submission);
         SubmissionBuffer.removeByUserId(userId);
         assertThat(SubmissionBuffer.findLastByUserId(userId)).isEmpty();
     }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBufferTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/submission/infrastructure/adapter/out/buffer/SubmissionBufferTest.java
@@ -1,0 +1,36 @@
+package com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer;
+
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
+import com.itachallenges.challengeservice.submission.domain.Submission;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.UUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubmissionBufferTest {
+    private final UserId userId = new UserId(UUID.fromString("660e8400-e29b-41d4-a716-446655440001"));
+    private Submission submission;
+
+    @BeforeEach
+    void setUp() {
+        SubmissionBuffer.clear();
+        submission = Submission.createInProgress(SubmissionId.generate(),
+                new ChallengeId(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
+                userId, "code");
+    }
+
+    @Test
+    void should_save_and_find() {
+        SubmissionBuffer.save(userId, submission);
+        assertThat(SubmissionBuffer.findLastByUserId(userId)).isPresent();
+    }
+
+    @Test
+    void should_remove() {
+        SubmissionBuffer.save(userId, submission);
+        SubmissionBuffer.removeByUserId(userId);
+        assertThat(SubmissionBuffer.findLastByUserId(userId)).isEmpty();
+    }
+}


### PR DESCRIPTION
**This is PR is an addendum, is optional, adds a functionality that is needed but will be fullly deployed in a future iteration. This means that is not prioriitary**


## Context
As part of the redesign of the submission flow, an in-memory buffer is 
introduced to hold only the active draft (IN_PROGRESS) for each user, 
separate from the historical repository (SubmissionRepository), which 
will continue to store all submissions (both IN_PROGRESS and SUBMITTED).

This sub-issue covers exclusively the buffer infrastructure piece and 
the changes needed in the Submission domain model to support state 
transitions without breaking its value-object-oriented design. 
Integration with the use case handlers (SaveDraftSubmission, 
FinalizeSubmission, MarkIncomplete) is addressed in a follow-up sub-issue.

## Changes

### New: `SubmissionBuffer`
- Static utility class (no DI, static `Map<UserId, Submission>`).
- Indexed solely by `UserId` "a user can only have one active draft in 
the entire system, regardless of challenge.
- `save(userId, submission)`: stores the draft; throws 
"If the submission is not in" 
status.
- `findLastByUserId(userId)`: returns the user's active draft, if any.
- `existsByUserId(userId)`: checks whether the user has an active draft.
- `removeByUserId(userId)`: removes the user's draft (e.g., on finalize).
- `clear()`: empties the whole buffer (intended for test use).

### Modified: `Submission`
The following methods are added, with existing ones 
(`createInProgress`, `createSubmitted`) left unchanged:

- `restore(id, challengeId, userId, status, code, createdAt, updatedAt)`: 
  reconstructs a submission, preserving its original status and 
timestamps, intended for deserialization from persistence.
- `toSubmitted(draft)`: creates a new instance from an IN_PROGRESS draft. 
  marking it as SUBMITTED; preserves id/challengeId/userId/code/createdAt 
and refreshes updatedAt.
- `toInProgress(existing)`: creates a new instance from an existing one 
  submission, moving it back to IN_PROGRESS (use case: marking as 
  incomplete); preserves id/challengeId/userId/code/createdAt and 
refreshes updatedAt.
- `updateCode(newCode)`: the class's only mutator; updates `code` and 
``in place. Intended for use only while the submission is 
IN_PROGRESS (invariant enforced by the caller, not by the class itself).

###Notes
Because the limit of 100 lines in every PR the tests for both classes will be add in a future PR