### PR TITLE
Implement draft submission lifecycle (save, finalize, mark incomplete)

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -23,27 +23,18 @@ public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCa
 
     @Override
     public void execute(FinalizeSubmissionCommand command) {
-        UserId userId = UserId.of(command.userId());
-        ChallengeId challengeId = ChallengeId.of(command.challengeId());
+        var userId = UserId.of(command.userId());
+        var challengeId = ChallengeId.of(command.challengeId());
 
-        // Buscar el draft activo del usuario en el buffer
-        Optional<Submission> activeDraft = SubmissionBuffer.findLastByUserId(userId);
-        if (activeDraft.isEmpty()) {
-            throw new NoSuchElementException("No active draft found for user: " + userId);
-        }
+        var draft = SubmissionBuffer.findLastByUserId(userId)
+                .filter(submission -> submission.getChallengeId().equals(challengeId))
+                .orElseThrow(() -> new NoSuchElementException(
+                        "No active draft found for user: " + userId + " or challenge mismatch"
+                ));
 
-        Submission draft = activeDraft.get();
-        if (!draft.getChallengeId().equals(challengeId)) {
-            throw new IllegalStateException(
-                    "Active draft belongs to a different challenge than the one being finalized");
-        }
+        Optional.ofNullable(command.code()).ifPresent(draft::updateCode);
 
-        if (command.code() != null) {
-            draft.updateCode(command.code());
-        }
-        Submission finalized = Submission.toSubmitted(draft);
-
-        repository.save(finalized);
+        repository.save(Submission.toSubmitted(draft));
         SubmissionBuffer.removeByUserId(userId);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -26,6 +26,7 @@ public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCa
         UserId userId = UserId.of(command.userId());
         ChallengeId challengeId = ChallengeId.of(command.challengeId());
 
+        // Buscar el draft activo del usuario en el buffer
         Optional<Submission> activeDraft = SubmissionBuffer.findLastByUserId(userId);
         if (activeDraft.isEmpty()) {
             throw new NoSuchElementException("No active draft found for user: " + userId);
@@ -40,11 +41,9 @@ public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCa
         if (command.code() != null) {
             draft.updateCode(command.code());
         }
-
         Submission finalized = Submission.toSubmitted(draft);
 
         repository.save(finalized);
-
         SubmissionBuffer.removeByUserId(userId);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -1,19 +1,43 @@
 package com.itachallenges.challengeservice.submission.application.usecase;
 
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.application.dto.FinalizeSubmissionCommand;
+import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.in.FinalizeSubmissionUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer.SubmissionBuffer;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCase {
-    // TODO: inject SubmissionRepository and any other dependencies
+
+    private final SubmissionRepository repository;
+
+    public FinalizeSubmissionUseCaseHandler(SubmissionRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void execute(FinalizeSubmissionCommand command) {
-        // TODO: check no FINAL submission exists for this user/challenge
-        // TODO: load or create submission
-        // TODO: call submission.finalize()
-        // TODO: save submission
-        // TODO: publish domain events
-    }
+        UserId userId = UserId.of(command.userId());
+        ChallengeId challengeId = ChallengeId.of(command.challengeId());
+        Optional<Submission> activeDraft = SubmissionBuffer.findLastByUserId(userId);
+        if (activeDraft.isEmpty()) {
+            throw new NoSuchElementException("No active draft found for user: " + userId);
+        }
+
+        Submission draft = activeDraft.get();
+        if (!draft.getChallengeId().equals(challengeId)) {
+            throw new IllegalStateException(
+                    "Active draft belongs to a different challenge than the one being finalized");
+        }
+        if (command.code() != null) {
+            draft.updateCode(command.code());
+        }
+        repository.save(finalized);
+        SubmissionBuffer.removeByUserId(userId);
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/FinalizeSubmissionUseCaseHandler.java
@@ -25,6 +25,7 @@ public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCa
     public void execute(FinalizeSubmissionCommand command) {
         UserId userId = UserId.of(command.userId());
         ChallengeId challengeId = ChallengeId.of(command.challengeId());
+
         Optional<Submission> activeDraft = SubmissionBuffer.findLastByUserId(userId);
         if (activeDraft.isEmpty()) {
             throw new NoSuchElementException("No active draft found for user: " + userId);
@@ -35,9 +36,15 @@ public class FinalizeSubmissionUseCaseHandler implements FinalizeSubmissionUseCa
             throw new IllegalStateException(
                     "Active draft belongs to a different challenge than the one being finalized");
         }
+
         if (command.code() != null) {
             draft.updateCode(command.code());
         }
+
+        Submission finalized = Submission.toSubmitted(draft);
+
         repository.save(finalized);
+
         SubmissionBuffer.removeByUserId(userId);
+    }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
@@ -6,13 +6,30 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MarkIncompleteUseCaseHandler implements MarkIncompleteUseCase {
-    // TODO: inject SubmissionRepository and any other dependencies
+    private final SubmissionRepository repository;
+
+    public MarkIncompleteUseCaseHandler(SubmissionRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void execute(MarkIncompleteCommand command) {
-        // TODO: load submission
-        // TODO: call submission.markIncomplete()
-        // TODO: save submission
-        // TODO: publish domain events
+        SubmissionId submissionId = SubmissionId.of(command.submissionId());
+        UserId userId = UserId.of(command.userId());
+
+        // Buscar la submission en el repositorio histórico (por ID)
+        Optional<Submission> existing = repository.findById(submissionId);
+        if (existing.isEmpty()) {
+            throw new NoSuchElementException("Submission not found with id: " + submissionId);
+        }
+
+        Submission found = existing.get();
+        if (!found.getUserId().equals(userId)) {
+            throw new IllegalStateException("Submission does not belong to the given user");
+        }
+
+        Submission incomplete = Submission.toInProgress(found);
+        SubmissionBuffer.save(userId, incomplete);
+        repository.save(incomplete);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/MarkIncompleteUseCaseHandler.java
@@ -1,11 +1,19 @@
 package com.itachallenges.challengeservice.submission.application.usecase;
 
+import com.itachallenges.challengeservice.shared.domain.valueobject.UserId;
 import com.itachallenges.challengeservice.submission.application.dto.MarkIncompleteCommand;
+import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.in.MarkIncompleteUseCase;
+import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
+import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer.SubmissionBuffer;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
 
 @Service
 public class MarkIncompleteUseCaseHandler implements MarkIncompleteUseCase {
+
     private final SubmissionRepository repository;
 
     public MarkIncompleteUseCaseHandler(SubmissionRepository repository) {
@@ -14,21 +22,16 @@ public class MarkIncompleteUseCaseHandler implements MarkIncompleteUseCase {
 
     @Override
     public void execute(MarkIncompleteCommand command) {
-        SubmissionId submissionId = SubmissionId.of(command.submissionId());
-        UserId userId = UserId.of(command.userId());
+        var submissionId = SubmissionId.of(command.submissionId());
+        var userId = UserId.of(command.userId());
 
-        // Buscar la submission en el repositorio histórico (por ID)
-        Optional<Submission> existing = repository.findById(submissionId);
-        if (existing.isEmpty()) {
-            throw new NoSuchElementException("Submission not found with id: " + submissionId);
-        }
+        var found = repository.findById(submissionId)
+                .filter(submission -> submission.getUserId().equals(userId))
+                .orElseThrow(() -> new NoSuchElementException(
+                        "Submission not found with id: " + submissionId + " or does not belong to user"
+                ));
 
-        Submission found = existing.get();
-        if (!found.getUserId().equals(userId)) {
-            throw new IllegalStateException("Submission does not belong to the given user");
-        }
-
-        Submission incomplete = Submission.toInProgress(found);
+        var incomplete = Submission.toInProgress(found);
         SubmissionBuffer.save(userId, incomplete);
         repository.save(incomplete);
     }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -10,8 +10,6 @@ import com.itachallenges.challengeservice.submission.domain.valueobject.Submissi
 import com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer.SubmissionBuffer;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
 
@@ -23,27 +21,23 @@ public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUse
 
     @Override
     public void execute(SaveDraftSubmissionCommand command) {
-        UserId userId = UserId.of(command.userId());
-        ChallengeId challengeId = ChallengeId.of(command.challengeId());
-        String code = command.code();
-        Optional<Submission> existingDraft = SubmissionBuffer.findLastByUserId(userId);
+        var userId = UserId.of(command.userId());
+        var challengeId = ChallengeId.of(command.challengeId());
+        var code = command.code();
 
-        Submission submission;
+        var submission = SubmissionBuffer.findLastByUserId(userId)
+                .map(existing -> {
+                    existing.updateCode(code);
+                    return existing;
+                })
+                .orElseGet(() -> Submission.createInProgress(
+                        SubmissionId.generate(),
+                        challengeId,
+                        userId,
+                        code
+                ));
 
-        if (existingDraft.isPresent()) {
-            submission = existingDraft.get();
-            submission.updateCode(code);
-        } else {
-            submission = Submission.createInProgress(
-                    SubmissionId.generate(),
-                    challengeId,
-                    userId,
-                    code
-            );
-        }
         SubmissionBuffer.save(userId, submission);
-
-        // Guardar en el repositorio histórico
         repository.save(submission);
     }
 }

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/submission/application/usecase/SaveDraftSubmissionUseCaseHandler.java
@@ -7,7 +7,10 @@ import com.itachallenges.challengeservice.submission.domain.Submission;
 import com.itachallenges.challengeservice.submission.domain.port.in.SaveDraftSubmissionUseCase;
 import com.itachallenges.challengeservice.submission.domain.port.out.SubmissionRepository;
 import com.itachallenges.challengeservice.submission.domain.valueobject.SubmissionId;
+import com.itachallenges.challengeservice.submission.infrastructure.adapter.out.buffer.SubmissionBuffer;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUseCase {
@@ -20,14 +23,27 @@ public class SaveDraftSubmissionUseCaseHandler implements SaveDraftSubmissionUse
 
     @Override
     public void execute(SaveDraftSubmissionCommand command) {
+        UserId userId = UserId.of(command.userId());
+        ChallengeId challengeId = ChallengeId.of(command.challengeId());
+        String code = command.code();
+        Optional<Submission> existingDraft = SubmissionBuffer.findLastByUserId(userId);
 
-        Submission submission = Submission.createInProgress(
-                SubmissionId.generate(),
-                ChallengeId.of(command.challengeId()),
-                UserId.of(command.userId()),
-                command.code()
-        );
+        Submission submission;
 
+        if (existingDraft.isPresent()) {
+            submission = existingDraft.get();
+            submission.updateCode(code);
+        } else {
+            submission = Submission.createInProgress(
+                    SubmissionId.generate(),
+                    challengeId,
+                    userId,
+                    code
+            );
+        }
+        SubmissionBuffer.save(userId, submission);
+
+        // Guardar en el repositorio histórico
         repository.save(submission);
     }
 }


### PR DESCRIPTION
> **Depends on #1056 ** — requires `SubmissionBuffer` and the 
> `Submission` transition methods (`restore`, `toSubmitted`, 
> `toInProgress`, `updateCode`) introduced there. Do not merge before that PR.

> **No tests included in this PR.** Test coverage for the three handlers 
> is tracked separately / to be added in a follow-up.

## Summary
Implements the use case logic that was left as stubs after the previous 
PR (`SubmissionBuffer` + `Submission` transition methods).

## What changed
- `SaveDraftSubmissionUseCaseHandler`: now checks the buffer for an 
  existing draft before creating a new `Submission`; updates code 
  in-place when a draft is found, otherwise creates one. Persists to 
  both buffer and historical repository on every call.
- `FinalizeSubmissionUseCaseHandler`: fully implemented. Pulls the 
  active draft from the buffer, validates it matches the command's 
  challenge, transitions it to `SUBMITTED`, persists it, and clears 
  the buffer entry.
- `MarkIncompleteUseCaseHandler`: fully implemented. Pulls the 
  submission from the historical repository by id, validates ownership, 
  transitions it back to `IN_PROGRESS`, and writes the result back to 
  both the buffer and the historical repository.

## Why
- Keeps the active-draft buffer as the single source of truth for "what 
  is currently in progress," while the historical repository remains 
  the append-friendly record of everything that happened — avoids 
  mixing two different lifecycles in one data structure.
- Adds two validations beyond the literal ask, both justified on 
  correctness/security grounds rather than style:
  - `userId` ownership check in `MarkIncomplete` — without it, knowing a 
    `submissionId` would be enough to tamper with someone else's 
    submission.
  - `challengeId` consistency check in `Finalize` — cheap to run, turns 
    a possible silent-wrong-challenge bug into an explicit failure.

## Out of scope
- Disk persistence for the historical repository.
- Frontend integration (save/finalize buttons).
- **Test coverage** — explicitly not included in this PR.