### PR TITLE
feat(challenges-list-page): filter challenges by language via backend #1011

### DIFF
--- a/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
+++ b/frontend/src/app/features/challenges/data-access/challenge-api.service.ts
@@ -2,9 +2,10 @@ import { inject, Injectable } from '@angular/core';
 import { IChallengeRequest } from '../models/ichallenge-request.interface';
 import { IChallenge } from '../models/ichallenge.interface';
 import { catchError, Observable, of } from 'rxjs';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { CHALLENGES_MOCK } from '../models/challenges.mock';
 import { IChallengeSubmission } from '../models/ichallenge-submission.interface';
+import { ChallengeLanguage } from '../models/challenge-language.type';
 
 @Injectable({
   providedIn: 'root',
@@ -28,8 +29,11 @@ export class ChallengeApiService {
     );
   }
 
-  loadAll(): Observable<IChallenge[]> {
-    return this.http.get<IChallenge[]>(this.apiUrl).pipe(
+  loadAll(language?: ChallengeLanguage | null): Observable<IChallenge[]> {
+    const params = language
+      ? new HttpParams().set('language', language)
+      : undefined;
+    return this.http.get<IChallenge[]>(this.apiUrl, { params }).pipe(
       catchError((error: HttpErrorResponse) => {
         return of(CHALLENGES_MOCK);
       }),

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.spec.ts
@@ -106,4 +106,24 @@ describe('ChallengesListPage', () => {
     expect(component.challenges().length).toBe(initialLength - 1);
     expect(component.challenges().some(c => c.id === CHALLENGES_MOCK[0].id)).toBe(false);
   });
+
+  it('should set selectedLanguage when a language chip is clicked', () => {
+    component.onLanguageChipClick('JAVA');
+    expect(component.selectedLanguage()).toBe('JAVA');
+    expect(mockChallengeService.loadAll).toHaveBeenCalledWith('JAVA');
+  });
+
+  it('should deselect language when the active chip is clicked again', () => {
+    component.onLanguageChipClick('JAVA');
+    component.onLanguageChipClick('JAVA');
+    expect(component.selectedLanguage()).toBeNull();
+    expect(mockChallengeService.loadAll).toHaveBeenCalledWith(null);
+  });
+
+  it('should change selected language when a different chip is clicked', () => {
+    component.onLanguageChipClick('JAVA');
+    component.onLanguageChipClick('PHP');
+    expect(component.selectedLanguage()).toBe('PHP');
+    expect(mockChallengeService.loadAll).toHaveBeenCalledWith('PHP');
+  });
 });

--- a/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
+++ b/frontend/src/app/features/challenges/pages/challenges-list-page/challenges-list-page.ts
@@ -26,6 +26,7 @@ export class ChallengesListPage implements OnInit {
 
   challenges = signal<IChallenge[]>([]);
   isMentor = signal(false);
+  selectedLanguage = signal<ChallengeLanguage | null>(null);
 
   languageLabels: Record<ChallengeLanguage, string> = {
     JAVA: 'Java',
@@ -54,8 +55,8 @@ export class ChallengesListPage implements OnInit {
     return diff ? this.difficultyLabels[diff] : '';
   }
 
-  loadChallenges(): void {
-    this.challengesService.loadAll().subscribe({
+  loadChallenges(language?: ChallengeLanguage | null): void {
+    this.challengesService.loadAll(language).subscribe({
       next: (result) => {
         this.challenges.set(result);
       }
@@ -64,6 +65,12 @@ export class ChallengesListPage implements OnInit {
 
   onRoleChange(value: boolean): void {
     this.isMentor.set(value);
+  }
+
+  onLanguageChipClick(lang: ChallengeLanguage): void {
+    const next = this.selectedLanguage() === lang ? null : lang;
+    this.selectedLanguage.set(next);
+    this.loadChallenges(next);
   }
 
   handleDelete(id: string): void {

--- a/frontend/src/app/features/challenges/services/challenge.service.ts
+++ b/frontend/src/app/features/challenges/services/challenge.service.ts
@@ -3,6 +3,7 @@ import { IChallengeRequest } from '../models/ichallenge-request.interface';
 import { IChallenge } from '../models/ichallenge.interface';
 import { map, Observable } from 'rxjs';
 import { ChallengeApiService } from '../data-access/challenge-api.service';
+import { ChallengeLanguage } from '../models/challenge-language.type';
 
 @Injectable({
   providedIn: 'root',
@@ -16,8 +17,8 @@ export class ChallengeService {
     return this.challengeApiService.create(challenge);
   }
 
-  loadAll(): Observable<IChallenge[]> {
-    return this.challengeApiService.loadAll();
+  loadAll(language?: ChallengeLanguage | null): Observable<IChallenge[]> {
+    return this.challengeApiService.loadAll(language);
   }
 
   update(id: string, challenge: IChallengeRequest): Observable<IChallenge> {


### PR DESCRIPTION
## Description
Third PR of the language filter feature. Connects the language filter chips to the backend, delegating the filtering logic to the existing `GET /api/challenge?language=` endpoint.

> ⚠️ This PR depends on #1053 and the challenges-list integration PR (#1054). Merge those first before merging this.

## Changes
- `ChallengeApiService.loadAll()` accepts an optional `language` parameter and builds the `?language=` query param conditionally
- `ChallengeService.loadAll()` propagates the parameter to the API service
- `ChallengesListPage.onLanguageChipClick()` triggers a new backend request on each chip toggle
- Add tests for onLanguageChipClick() method

## Why backend filtering
The backend already exposes `GET /api/challenge?language=` for this purpose, so filtering on the frontend would mean loading all challenges unnecessarily.