### PR TITLE
feat: add CONVIDAT state to header for unauthenticated users

### DIFF
--- a/frontend/src/app/layout/components/header/header.html
+++ b/frontend/src/app/layout/components/header/header.html
@@ -15,8 +15,11 @@
       </div>
     </div>
   } @else {
+    <div class="user__profile">
     <div class="button__login">
       <button>Log In</button>
+    </div>
+      <h4>INVITAT</h4>
     </div>
   }
 </header>

--- a/frontend/src/app/layout/components/header/header.html
+++ b/frontend/src/app/layout/components/header/header.html
@@ -16,10 +16,10 @@
     </div>
   } @else {
     <div class="user__profile">
-    <div class="button__login">
-      <button>Log In</button>
-    </div>
-      <h4>INVITAT</h4>
+      <div class="button__login">
+        <button>Log In</button>
+      </div>
+      <h4>CONVIDAT</h4>
     </div>
   }
 </header>

--- a/frontend/src/app/layout/components/header/header.spec.ts
+++ b/frontend/src/app/layout/components/header/header.spec.ts
@@ -89,8 +89,20 @@ describe('Header', () => {
     authServiceMock.user.set(null);
     fixture.detectChanges();
 
+    const usernameDiv = fixture.nativeElement.querySelector('.user__username');
+    expect(usernameDiv).toBeFalsy();
+  });
+
+  it('should show INVITAT and Log In button when user is not logged in', () => {
+    authServiceMock.user.set(null);
+    fixture.detectChanges();
+
     const h4 = fixture.nativeElement.querySelector('h4');
-    expect(h4).toBeFalsy();
+    const loginButton = fixture.nativeElement.querySelector('.button__login button');
+
+    expect(h4.textContent).toContain('INVITAT');
+    expect(loginButton).toBeTruthy();
+    expect(loginButton.textContent).toContain('Log In');
   });
 
   it('should show user avatar when user is logged in', () => {


### PR DESCRIPTION
Description
This PR implements the UI changes required to display the "CONVIDAT" label alongside the Log In button when there is no active user session. This ensures visual consistency with the authenticated state (where the user's role, like STUDENT, is shown) and prevents the header from looking empty.

Technical Changes

Updated header.html to include the INVITAT label within the @else block.

Wrapped the unauthenticated UI elements in the .user__profile div to maintain consistent layout, spacing, and CSS alignment.

Kept the defensive ?? 'CONVIDAT' logic for authenticated users missing a role.

Updated unit tests in header.spec.ts:

Refactored the unauthenticated username visibility test to target .user__username instead of the generic h4 tag.

Added a new test to verify that the INVITAT text and the "Log In" button are rendered correctly when the user signal is null.

Closes #1061