### PR TITLE
[#999 TICKET] Show the current assignee on each ticket card (UI Split)

### DIFF
--- a/frontend/src/app/features/tickets/components/ticket-card/ticket-card.css
+++ b/frontend/src/app/features/tickets/components/ticket-card/ticket-card.css
@@ -1,7 +1,7 @@
 .ticket-card {
   display: grid;
   width: fit-content;
-  grid-template-columns: repeat(3, 10rem) 12rem repeat(2, 15rem) 14rem;
+  grid-template-columns: repeat(3, 10rem) 12rem repeat(2, 15rem) repeat(2,14rem);
   gap: 0.8rem;
   align-items: center;
   background: var(--color-white);

--- a/frontend/src/app/features/tickets/components/ticket-card/ticket-card.html
+++ b/frontend/src/app/features/tickets/components/ticket-card/ticket-card.html
@@ -5,5 +5,11 @@
   <span class="ticket-description">{{ ticket().description }}</span>
   <span class="ticket-description">{{ ticket().createdAt | date:'dd/MM/yyyy HH:mm' }}</span>
   <span class="ticket-description">{{ ticket().updatedAt | date:'dd/MM/yyyy HH:mm' }}</span>
+  <select name="assigned-to">
+    <option [value]="null" [selected]="!ticket().mentorAssignedId">Sense assignar</option>
+    @for(user of assignableUsers(); track user.username){
+      <option [value]="user.username" [selected]="user.username === ticket().mentorAssignedId">{{user.username}}</option>
+    }
+  </select>
   <app-ticket-button [routerLink]="['/tickets', ticket().id]" [label]="'Accedir'"/>
 </div>

--- a/frontend/src/app/features/tickets/components/ticket-card/ticket-card.spec.ts
+++ b/frontend/src/app/features/tickets/components/ticket-card/ticket-card.spec.ts
@@ -1,23 +1,36 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideRouter } from '@angular/router';
 import { TicketCard } from './ticket-card';
+import { TicketStatus } from '../../models/status.enum';
 
 describe('TicketCard', () => {
   let component: TicketCard;
   let fixture: ComponentFixture<TicketCard>;
+  const mockUsers = [{ username: 'mentor1', role: 'mentor' }];
+  const mockTicket = { id: '1', userId: 'u-1', title: 'T', description: 'D', status: TicketStatus.OPEN, comment: null, createdAt: new Date(), updatedAt: new Date() };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TicketCard]
-    })
-    .compileComponents();
+      imports: [TicketCard],
+      providers: [provideRouter([])]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(TicketCard);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('ticket', mockTicket);
+    fixture.componentRef.setInput('assignableUsers', mockUsers);
+    fixture.detectChanges();
     await fixture.whenStable();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should render a select with one option per user plus "Sense assignar"', () => {
+    const options = fixture.nativeElement.querySelectorAll('option');
+    expect(options.length).toBe(mockUsers.length + 1);
+  });
+
+  it('should select "Sense assignar" when no mentor is assigned', () => {
+    fixture.componentRef.setInput('ticket', { ...mockTicket, mentorAssignedId: null });
+    fixture.detectChanges();
+    expect((fixture.nativeElement.querySelector('option') as HTMLOptionElement).selected).toBe(true);
   });
 });

--- a/frontend/src/app/features/tickets/components/ticket-card/ticket-card.ts
+++ b/frontend/src/app/features/tickets/components/ticket-card/ticket-card.ts
@@ -3,6 +3,7 @@ import { ITicket } from '../../models/iticket.interface';
 import { RouterLink } from '@angular/router';
 import { TicketButton } from '../ticket-button/ticket-button';
 import { DatePipe } from '@angular/common';
+import { AssignableUser } from '../../models/assignable-user.interface';
 
 @Component({
   selector: 'app-ticket-card',
@@ -12,4 +13,5 @@ import { DatePipe } from '@angular/common';
 })
 export class TicketCard {
   ticket = input.required<ITicket>();
+  assignableUsers = input.required<AssignableUser[]>();
 }

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.css
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.css
@@ -1,6 +1,6 @@
 .tickets-header {
   display: grid;
-  grid-template-columns: repeat(3, 10rem) 12rem repeat(2, 15rem) 14rem;
+  grid-template-columns: repeat(3, 10rem) 12rem repeat(2, 15rem) repeat(2,14rem);
   gap: 0.8rem;
   align-items: center;
   padding: 1.4rem 2rem;

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.html
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.html
@@ -7,8 +7,10 @@
   <span>Descripció</span>
   <span>Creat</span>
   <span>Actualitzat</span>
+  <span>Assignat a</span>
 </div>
 
 @for (ticket of tickets(); track ticket.id) {
-  <app-ticket-card [ticket]="ticket" />
+  <app-ticket-card [ticket]="ticket" [assignableUsers]="assignableUsers()"" />
+  
 }

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.spec.ts
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 
 import { TicketListPage } from './ticket-list-page';
 import { TicketApiService } from '../../data-access/ticket-api.service';
+import { TicketService } from '../../ticket.service';
 import { TICKETS_MOCK } from '../../models/tickets.mock';
 import { provideRouter, RouterLink } from '@angular/router';
 import { By } from '@angular/platform-browser';
@@ -11,15 +12,18 @@ describe('TicketListPage', () => {
   let component: TicketListPage;
   let fixture: ComponentFixture<TicketListPage>;
   let mockTicketApiService: Partial<TicketApiService>;
+  let mockTicketService: { getTicketAssignableUsers: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     TestBed.resetTestingModule();
     mockTicketApiService = { loadAll: vi.fn().mockReturnValue(of(TICKETS_MOCK)) };
+    mockTicketService = { getTicketAssignableUsers: vi.fn().mockReturnValue(of([])) };
 
     await TestBed.configureTestingModule({
       imports: [TicketListPage],
       providers: [
         { provide: TicketApiService, useValue: mockTicketApiService },
+        { provide: TicketService, useValue: mockTicketService },
         provideRouter([])
       ]
     }).compileComponents();
@@ -52,7 +56,15 @@ describe('TicketListPage', () => {
   });
 
   it('should have a routerLink button for each ticket', () => {
-  const links = fixture.debugElement.queryAll(By.directive(RouterLink));
-  expect(links.length).toBe(TICKETS_MOCK.length);
+    const links = fixture.debugElement.queryAll(By.directive(RouterLink));
+    expect(links.length).toBe(TICKETS_MOCK.length);
+  });
+
+  it('should call getTicketAssignableUsers on init', () => {
+    expect(mockTicketService.getTicketAssignableUsers).toHaveBeenCalled();
+  });
+
+  it('should populate assignableUsers signal from TicketService', () => {
+    expect(component.assignableUsers()).toEqual([]);
   });
 });

--- a/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.ts
+++ b/frontend/src/app/features/tickets/pages/ticket-list-page/ticket-list-page.ts
@@ -2,6 +2,8 @@ import { Component, inject, signal } from '@angular/core';
 import { TicketApiService } from '../../data-access/ticket-api.service';
 import { ITicket } from '../../models/iticket.interface';
 import { TicketCard } from "../../components/ticket-card/ticket-card";
+import { AssignableUser } from '../../models/assignable-user.interface';
+import { TicketService } from '../../ticket.service';
 
 @Component({
   selector: 'app-ticket-list-page',
@@ -11,13 +13,18 @@ import { TicketCard } from "../../components/ticket-card/ticket-card";
   styleUrl: './ticket-list-page.css',
 })
 export class TicketListPage {
-  private readonly ticketService = inject(TicketApiService);
+  private readonly ticketApiService = inject(TicketApiService);
+  private readonly ticketService = inject(TicketService);
 
   tickets = signal<ITicket[]>([]);
+  assignableUsers = signal<AssignableUser[]>([]);
 
   ngOnInit(): void {
-    this.ticketService.loadAll().subscribe((data) => {
+    this.ticketApiService.loadAll().subscribe((data) => {
       this.tickets.set(data);
+    });
+    this.ticketService.getTicketAssignableUsers().subscribe((data) => {
+      this.assignableUsers.set(data)
     })
   }
 }


### PR DESCRIPTION
### PR summary after split request from @kenan-it-academy

The preceding data layer PR is #1046.
> ⚠️ This pull request depends on PR #1046. Please merge this first before merging this one.
Because of this dependency, tests and automated PR checks may fail until the pull requests are merged in the correct order.

### Summary

> Note: This PR contains the UI layer half of a split from the original ticket.
> The full feature — showing the current assignee on each ticket card — was split into a data layer PR and a UI layer PR as requested, keeping the changes reviewable and focused.

* **TicketCard assignable users input**

  * Added a new required signal input, `assignableUsers`, of type `AssignableUser[]`.
  * This input receives the list of mentors that can be assigned to a ticket.

* **TicketCard template**

  * Added a `<select>` dropdown for assigning mentors.
  * The dropdown iterates over `assignableUsers`.
  * It pre-selects the option matching `ticket().mentorAssignedId`.
  * If no mentor is assigned, it selects `"Sense assignar"`.

* **Grid layout**

  * Updated `ticket-card.css` and `ticket-list-page.css` to add a new column for the assignee field.
  * Updated the header with the `"Assignat a"` label.

* **TicketListPage**

  * Injected `TicketService` alongside `TicketApiService`.
  * Added an `assignableUsers` signal.
  * Populated `assignableUsers` from `getTicketAssignableUsers()` on init.
  * Passed `assignableUsers` down to each `<app-ticket-card>`.

* **Spec updates**

  * Rewritten `TicketCard` spec to include the required inputs.
  * Added two new `TicketCard` tests.
  * Extended `TicketListPage` spec with a proper `TicketService` mock.
  * Added two new `TicketListPage` tests covering the assignable users flow.

### Test plan

* [x] `TicketCard` — renders a select with one option per user plus `"Sense assignar"`
* [x] `TicketCard` — selects `"Sense assignar"` when no mentor is assigned
* [x] `TicketListPage` — calls `getTicketAssignableUsers()` on init
* [x] `TicketListPage` — populates the `assignableUsers` signal from `TicketService`
* [x] Existing `TicketListPage` specs still pass:

  * `loadAll` is called
  * tickets are rendered
  * `routerLink`s are present

### Preview
<img width="1129" height="445" alt="611757253-00cbb7c4-0fff-4ea8-8402-530fe7c3b27c" src="https://github.com/user-attachments/assets/c96a2675-07ac-482f-be46-6e1dc2f240ae" />
