### PR TITLE
[CHALLENGE] Implement difficulty filter logic

### DIFF
--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/domain/port/out/ChallengeRepository.java
@@ -3,13 +3,14 @@ package com.itachallenges.challengeservice.catalog.domain.port.out;
 import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 
 import java.util.List;
 
 public interface ChallengeRepository {
 
     List<Challenge> findAll();
-    List<Challenge> findByLanguage(ChallengeLanguage language);
+    List<Challenge> findByCriteria(ChallengeLanguage language, ChallengeDifficulty difficulty);
     Challenge update(Challenge challenge);
     Challenge save(Challenge challenge);
     void delete(ChallengeId id);

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -4,6 +4,7 @@ import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeResponse;
 import com.itachallenges.challengeservice.catalog.infrastructure.adapter.web.in.dto.ChallengeRequest;
 import lombok.AllArgsConstructor;
@@ -41,10 +42,10 @@ public class ChallengeController {
 
     @GetMapping
     public ResponseEntity<List<ChallengeResponse>> findAll(
-            @RequestParam(required = false) ChallengeLanguage language
+            @RequestParam(required = false) ChallengeLanguage language,
+            @RequestParam(required = false) ChallengeDifficulty difficulty
     ) {
-        // Canvi aplicat: substitució del ternari per findByCriteria
-        List<Challenge> challenges = repository.findByCriteria(language, null);
+        List<Challenge> challenges = repository.findByCriteria(language, difficulty);
 
         List<ChallengeResponse> response = challenges.stream()
                 .map(c -> new ChallengeResponse(

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/in/controller/ChallengeController.java
@@ -43,9 +43,8 @@ public class ChallengeController {
     public ResponseEntity<List<ChallengeResponse>> findAll(
             @RequestParam(required = false) ChallengeLanguage language
     ) {
-        List<Challenge> challenges = (language == null)
-                ? repository.findAll()
-                : repository.findByLanguage(language);
+        // Canvi aplicat: substitució del ternari per findByCriteria
+        List<Challenge> challenges = repository.findByCriteria(language, null);
 
         List<ChallengeResponse> response = challenges.stream()
                 .map(c -> new ChallengeResponse(

--- a/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
+++ b/backend/challenge-service/src/main/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepository.java
@@ -4,9 +4,9 @@ import com.itachallenges.challengeservice.catalog.domain.model.Challenge;
 import com.itachallenges.challengeservice.catalog.domain.port.out.ChallengeRepository;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeId;
 import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeLanguage;
+import com.itachallenges.challengeservice.catalog.domain.valueobject.ChallengeDifficulty;
 import org.springframework.stereotype.Repository;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -57,9 +57,10 @@ public class InMemoryChallengeRepository implements ChallengeRepository {
     }
 
     @Override
-    public List<Challenge> findByLanguage(ChallengeLanguage language) {
+    public List<Challenge> findByCriteria(ChallengeLanguage language, ChallengeDifficulty difficulty) {
         return storage.values().stream()
-                .filter(c -> c.getLanguage() == language)
+                .filter(c -> language == null || c.getLanguage() == language)
+                .filter(c -> difficulty == null || c.getDifficulty() == difficulty)
                 .toList();
     }
 

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
@@ -28,7 +28,7 @@ class InMemoryChallengeRepositoryFilterTest {
         repository.save(java2);
         repository.save(python);
 
-        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.JAVA);
+        List<Challenge> result = repository.findByCriteria(ChallengeLanguage.JAVA, null);
 
         assertThat(result).hasSize(2);
         assertThat(result).extracting(Challenge::getLanguage).containsOnly(ChallengeLanguage.JAVA);
@@ -38,7 +38,7 @@ class InMemoryChallengeRepositoryFilterTest {
     void should_return_empty_list_when_no_challenges_match_language() {
         repository.save(Challenge.create("Java only", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol"));
 
-        List<Challenge> result = repository.findByLanguage(ChallengeLanguage.PYTHON);
+        List<Challenge> result = repository.findByCriteria(ChallengeLanguage.PYTHON, null);
 
         assertThat(result).isEmpty();
     }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/catalog/infrastructure/adapter/web/out/persistence/InMemoryChallengeRepositoryFilterTest.java
@@ -42,4 +42,46 @@ class InMemoryChallengeRepositoryFilterTest {
 
         assertThat(result).isEmpty();
     }
+
+    @Test
+    void should_return_only_challenges_with_given_difficulty() {
+        Challenge easy1 = Challenge.create("Easy 1", "Desc 1", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol 1");
+        Challenge easy2 = Challenge.create("Easy 2", "Desc 2", ChallengeLanguage.PYTHON, ChallengeDifficulty.EASY, "Sol 2");
+        Challenge hard = Challenge.create("Hard 1", "Desc 3", ChallengeLanguage.JAVA, ChallengeDifficulty.HARD, "Sol 3");
+        repository.save(easy1);
+        repository.save(easy2);
+        repository.save(hard);
+
+        List<Challenge> result = repository.findByCriteria(null, ChallengeDifficulty.EASY);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Challenge::getDifficulty).containsOnly(ChallengeDifficulty.EASY);
+    }
+
+    @Test
+    void should_return_challenges_matching_both_language_and_difficulty() {
+        Challenge javaEasy = Challenge.create("Java Easy", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol");
+        Challenge javaHard = Challenge.create("Java Hard", "Desc", ChallengeLanguage.JAVA, ChallengeDifficulty.HARD, "Sol");
+        Challenge pythonEasy = Challenge.create("Python Easy", "Desc", ChallengeLanguage.PYTHON, ChallengeDifficulty.EASY, "Sol");
+        repository.save(javaEasy);
+        repository.save(javaHard);
+        repository.save(pythonEasy);
+
+        List<Challenge> result = repository.findByCriteria(ChallengeLanguage.JAVA, ChallengeDifficulty.EASY);
+
+        assertThat(result).hasSize(1);
+        assertThat(result).first()
+                .extracting(Challenge::getLanguage, Challenge::getDifficulty)
+                .containsExactly(ChallengeLanguage.JAVA, ChallengeDifficulty.EASY);
+    }
+
+    @Test
+    void should_return_all_challenges_when_no_criteria_provided() {
+        repository.save(Challenge.create("C1", "D1", ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "S1"));
+        repository.save(Challenge.create("C2", "D2", ChallengeLanguage.PYTHON, ChallengeDifficulty.HARD, "S2"));
+
+        List<Challenge> result = repository.findByCriteria(null, null);
+
+        assertThat(result).hasSize(2);
+    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
@@ -57,4 +57,42 @@ class ChallengeControllerFilterTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
     }
+
+    @Test
+    void should_return_200_with_filtered_list_when_requesting_challenges_by_difficulty() throws Exception {
+        Challenge easyChallenge = Challenge.create(
+                "Easy Challenge", "Easy description",
+                ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Easy solution"
+        );
+        when(repository.findByCriteria(null, ChallengeDifficulty.EASY)).thenReturn(List.of(easyChallenge));
+
+        mockMvc.perform(get("/api/challenge").param("difficulty", "EASY"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].difficulty").value("EASY"));
+    }
+
+    @Test
+    void should_return_400_when_requesting_challenges_with_invalid_difficulty() throws Exception {
+        mockMvc.perform(get("/api/challenge").param("difficulty", "IMPOSSIBLE"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void should_return_200_with_filtered_list_when_combining_language_and_difficulty() throws Exception {
+        Challenge javaEasy = Challenge.create(
+                "Java Easy", "Desc",
+                ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Sol"
+        );
+        when(repository.findByCriteria(ChallengeLanguage.JAVA, ChallengeDifficulty.EASY))
+                .thenReturn(List.of(javaEasy));
+
+        mockMvc.perform(get("/api/challenge")
+                        .param("language", "JAVA")
+                        .param("difficulty", "EASY"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].language").value("JAVA"))
+                .andExpect(jsonPath("$[0].difficulty").value("EASY"));
+    }
 }

--- a/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
+++ b/backend/challenge-service/src/test/java/com/itachallenges/challengeservice/infrastructure/adapter/web/in/controller/ChallengeControllerFilterTest.java
@@ -34,7 +34,7 @@ class ChallengeControllerFilterTest {
                 "Java Challenge", "Java description",
                 ChallengeLanguage.JAVA, ChallengeDifficulty.EASY, "Java solution"
         );
-        when(repository.findByLanguage(ChallengeLanguage.JAVA)).thenReturn(List.of(javaChallenge));
+        when(repository.findByCriteria(ChallengeLanguage.JAVA, null)).thenReturn(List.of(javaChallenge));
 
         mockMvc.perform(get("/api/challenge").param("language", "JAVA"))
                 .andExpect(status().isOk())
@@ -51,7 +51,7 @@ class ChallengeControllerFilterTest {
 
     @Test
     void should_return_200_with_empty_list_when_filter_matches_no_challenges() throws Exception {
-        when(repository.findByLanguage(ChallengeLanguage.SQL)).thenReturn(List.of());
+        when(repository.findByCriteria(ChallengeLanguage.SQL, null)).thenReturn(List.of());
 
         mockMvc.perform(get("/api/challenge").param("language", "SQL"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
Closes #1006

Adds support for filtering challenges by difficulty via `GET /api/challenge?difficulty=EASY|MEDIUM|HARD`, combinable with the existing `?language=` filter from #1019.

## Changes
- Replaces `findByLanguage` with `findByCriteria(language, difficulty)` at the repository port; both parameters are optional (null = no filter).
- Adds `?difficulty` query param to `GET /api/challenge`.
- Tests added at repository and controller layers for difficulty filter,  combined filter, and invalid value (400 via Spring enum binding).

## Why a combined method instead of two parallel ones
The UI design (#985, #990) places language and difficulty filters as independent controls that users will naturally combine. A single 
`findByCriteria` keeps the controller free of branching logic and maps cleanly to a future `WHERE` clause when a persistent store is 
introduced.